### PR TITLE
Make plugins configurable

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -4,12 +4,7 @@ common:
   publish_topic: /NWC-CF/L3
   use_extern_calib: false
   # Scene creation settings
-  plugin_scene:
-    reader: nwcsaf-pps_nc
-  # Composite loader settings
-  #plugin_composites:
-  #  calibration: null
-  #  resolution: null
+  reader: nwcsaf-pps_nc
   fname_pattern: &fname
     "{platform_name}_{start_time:%Y%m%d_%H%M}_{areaname}_{productname}.{format}"
   formats: &formats
@@ -21,9 +16,9 @@ common:
 product_list: &product_list
   omerc_bb:
     # Resampler settings can be global (in common section above) or per area
-    #plugin_resample:
-    #  radius_of_influence: 5000
-    #  resampler: bilinear
+    #radius_of_influence: 5000
+    #resampler: bilinear
+    #reduce_data: False
     areaname: omerc_bb
     products:
       ct:

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -3,8 +3,10 @@ common:
     /tmp/satnfs/polar_out/pps2018/direct_readout/
   publish_topic: /NWC-CF/L3
   use_extern_calib: false
+  # Scene creation settings
   plugin_scene:
     reader: nwcsaf-pps_nc
+  # Composite loader settings
   #plugin_composites:
   #  calibration: null
   #  resolution: null
@@ -18,6 +20,10 @@ common:
 
 product_list: &product_list
   omerc_bb:
+    # Resampler settings can be global (in common section above) or per area
+    #plugin_resample:
+    #  radius_of_influence: 5000
+    #  resampler: bilinear
     areaname: omerc_bb
     products:
       ct:

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -3,6 +3,8 @@ common:
     /tmp/satnfs/polar_out/pps2018/direct_readout/
   publish_topic: /NWC-CF/L3
   use_extern_calib: false
+  plugin_scene:
+    reader: nwcsaf-pps_nc
   fname_pattern: &fname
     "{platform_name}_{start_time:%Y%m%d_%H%M}_{areaname}_{productname}.{format}"
   formats: &formats
@@ -105,7 +107,6 @@ product_list: &product_list
 
 workers:
   - fun: !!python/name:trollflow2.create_scene
-    reader: nwcsaf-pps_nc
   - fun: !!python/name:trollflow2.load_composites
   - fun: !!python/name:trollflow2.resample
   - fun: !!python/name:trollflow2.save_datasets

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -5,6 +5,9 @@ common:
   use_extern_calib: false
   plugin_scene:
     reader: nwcsaf-pps_nc
+  #plugin_composites:
+  #  calibration: null
+  #  resolution: null
   fname_pattern: &fname
     "{platform_name}_{start_time:%Y%m%d_%H%M}_{areaname}_{productname}.{format}"
   formats: &formats

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -54,9 +54,13 @@ class AbortProcessing(Exception):
     pass
 
 
-def create_scene(job, reader=None):
+def create_scene(job, name="plugin_scene"):
+    defaults = {'reader': None}
+    product_list = job['product_list']
+    conf = get_config_value(product_list, '/common', name, default={})
+    defaults.update(conf)
     LOG.info('Generating scene')
-    job['scene'] = Scene(filenames=job['input_filenames'], reader=reader)
+    job['scene'] = Scene(filenames=job['input_filenames'], **defaults)
 
 
 def load_composites(job):

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -63,11 +63,14 @@ def create_scene(job, name="plugin_scene"):
     job['scene'] = Scene(filenames=job['input_filenames'], **defaults)
 
 
-def load_composites(job):
+def load_composites(job, name="plugin_composites"):
+    defaults = {}
+    product_list = job['product_list']
+    conf = get_config_value(product_list, '/common', name, default={})
     composites = set(dpath.util.values(job['product_list'], '/product_list/*/products/*/productname'))
     LOG.info('Loading %s', str(composites))
     scn = job['scene']
-    scn.load(composites)
+    scn.load(composites, **conf)
     job['scene'] = scn
 
 

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -209,10 +209,10 @@ def gen_dict_extract(var, key):
                         yield result
 
 
-def get_config_value(config, path, key):
+def get_config_value(config, path, key, default=None):
     """Get the most local config value for key *key* starting from the
     dictionary path *path*. If nothing is found, path "/common/" is
-    also checked, and if still nothing is found, return None.
+    also checked, and if still nothing is found, return *default*.
     """
     path_parts = path.split('/')
     # Loop starting from the current path, and continue upwards
@@ -228,7 +228,7 @@ def get_config_value(config, path, key):
     if len(vals) > 0:
         return vals[0]
 
-    return None
+    return default
 
 
 from ._version import get_versions

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -74,13 +74,21 @@ def load_composites(job, name="plugin_composites"):
     job['scene'] = scn
 
 
-def resample(job, radius_of_influence=None):
+def resample(job, name="plugin_resample"):
+    defaults = {"radius_of_influence": None, "resampler": "nearest"}
+    product_list = job['product_list']
+    # Update global settings
+    conf = get_config_value(product_list, '/common', name, default={})
+    defaults.update(conf)
     job['resampled_scenes'] = {}
     scn = job['scene']
-    product_list = job['product_list']
     for area in product_list['product_list']:
+        conf = defaults.copy()
+        area_conf = get_config_value(product_list, '/product_list/' + area,
+                                     name, default={})
+        conf.update(area_conf)
         LOG.info('Resampling to %s', str(area))
-        job['resampled_scenes'][area] = scn.resample(area, radius_of_influence=radius_of_influence)
+        job['resampled_scenes'][area] = scn.resample(area, **conf)
 
 
 def save_datasets(job):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -334,6 +334,23 @@ class TestCovers(unittest.TestCase):
         area_coverage.assert_called_with(6)
 
 
+class TestGetPluginConf(unittest.TestCase):
+
+    def test_get_plugin_conf(self):
+        from trollflow2 import _get_plugin_conf
+        conf = {"common": {"val1": "foo1"},
+                "product_list": {"val2": "bar2"}}
+        path = "/product_list"
+        defaults = {"val1": "foo0", "val2": "bar0", "val3": "baz0"}
+        res = _get_plugin_conf(conf, path, defaults)
+        self.assertTrue("val1" in res)
+        self.assertTrue("val2" in res)
+        self.assertTrue("val3" in res)
+        self.assertEqual(res["val1"], "foo1")
+        self.assertEqual(res["val2"], "bar2")
+        self.assertEqual(res["val3"], "baz0")
+
+
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()
@@ -345,6 +362,7 @@ def suite():
     my_suite.addTest(loader.loadTestsFromTestCase(TestLoadComposites))
     my_suite.addTest(loader.loadTestsFromTestCase(TestResample))
     my_suite.addTest(loader.loadTestsFromTestCase(TestCovers))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestGetPluginConf))
 
     return my_suite
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -201,6 +201,12 @@ class TestConfigValue(unittest.TestCase):
         res = get_config_value(self.prodlist, self.path, "nothing")
         self.assertIsNone(res)
 
+    def test_config_value_missing_own_default(self):
+        from trollflow2 import get_config_value
+        res = get_config_value(self.prodlist, self.path, "nothing",
+                               default=42)
+        self.assertEqual(res, 42)
+
 
 class TestCreateScene(unittest.TestCase):
 
@@ -208,12 +214,18 @@ class TestCreateScene(unittest.TestCase):
     def test_create_scene(self, scene):
         from trollflow2 import create_scene
         scene.return_value = "foo"
-        job = {"input_filenames": "bar"}
+        job = {"input_filenames": "bar", "product_list": {}}
         create_scene(job)
         self.assertEqual(job["scene"], "foo")
         scene.assert_called_with(filenames='bar', reader=None)
-        create_scene(job, reader="baz")
-        scene.assert_called_with(filenames='bar', reader='baz')
+        job = {"input_filenames": "bar",
+               "product_list": {"common": {"plugin_scene": {"reader": "baz"}}}}
+        create_scene(job)
+        scene.assert_called_with(filenames='bar', reader="baz")
+        job = {"input_filenames": "bar",
+               "product_list": {"common": {"own_name": {"reader": "val"}}}}
+        create_scene(job, name="own_name")
+        scene.assert_called_with(filenames='bar', reader="val")
 
 
 class TestLoadComposites(unittest.TestCase):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -239,6 +239,12 @@ class TestLoadComposites(unittest.TestCase):
         job = {"product_list": self.product_list, "scene": scn}
         load_composites(job)
         scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'})
+        prod_list = self.product_list.copy()
+        prod_list["common"] = {"own_name": {"calibration": "foo"}}
+        job = {"product_list": prod_list, "scene": scn}
+        load_composites(job, name="own_name")
+        scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'},
+                                    calibration="foo")
 
 
 class TestResample(unittest.TestCase):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -259,18 +259,30 @@ class TestResample(unittest.TestCase):
         job = {"scene": scn, "product_list": self.product_list}
         resample(job)
         self.assertTrue(mock.call('omerc_bb',
-                                  radius_of_influence=None) in
+                                  radius_of_influence=None,
+                                  resampler="nearest") in
                         scn.resample.mock_calls)
         self.assertTrue(mock.call('germ',
-                                  radius_of_influence=None) in
+                                  radius_of_influence=None,
+                                  resampler="nearest") in
                         scn.resample.mock_calls)
         self.assertTrue(mock.call('euron1',
-                                  radius_of_influence=None) in
+                                  radius_of_influence=None,
+                                  resampler="nearest") in
                         scn.resample.mock_calls)
         self.assertTrue("resampled_scenes" in job)
         for area in ["omerc_bb", "germ", "euron1"]:
             self.assertTrue(area in job["resampled_scenes"])
             self.assertTrue(job["resampled_scenes"][area] == "foo")
+
+        prod_list = self.product_list.copy()
+        prod_list["common"] = {"own_name": {"resampler": "bilinear"}}
+        job = {"product_list": prod_list, "scene": scn}
+        resample(job, name="own_name")
+        self.assertTrue(mock.call('euron1',
+                                  radius_of_influence=None,
+                                  resampler="bilinear") in
+                        scn.resample.mock_calls)
 
 
 class TestCovers(unittest.TestCase):


### PR DESCRIPTION
This PR makes the plugins configurable without passing the config items via kwargs at initialization.
- The config values can be given in the product list
- The plugins can have internal defaults which will be used if no config can be found
- The settings can be at different levels of the config, e.g. each of the areas can have different resampling settings