### PR TITLE
Add a plugin to check platform name

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -29,7 +29,7 @@ import sys
 from multiprocessing import Process
 import yaml
 import time
-from trollflow2 import gen_dict_extract
+from trollflow2 import gen_dict_extract, AbortProcessing
 from collections import OrderedDict
 from six.moves.urllib.parse import urlparse
 
@@ -78,7 +78,10 @@ def process(msg, prod_list):
     job = message_to_job(msg, config)
     for wrk in config['workers']:
         cwrk = wrk.copy()
-        cwrk.pop('fun')(job, **cwrk)
+        try:
+            cwrk.pop('fun')(job, **cwrk)
+        except AbortProcessing:
+            LOG.info("Processing aborted for this scene")
 
 
 def main():

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -79,9 +79,10 @@ def process(msg, prod_list):
     for wrk in config['workers']:
         cwrk = wrk.copy()
         try:
-            cwrk.pop('fun')(job, **cwrk)
+            func = wrk('fun')
+            func(job, **cwrk)
         except AbortProcessing:
-            LOG.info("Processing aborted for this scene")
+            LOG.info("Processing aborted by '%s'", func.__name__)
 
 
 def main():

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -79,7 +79,7 @@ def process(msg, prod_list):
     for wrk in config['workers']:
         cwrk = wrk.copy()
         try:
-            func = wrk('fun')
+            func = cwrk.pop('fun')
             func(job, **cwrk)
         except AbortProcessing:
             LOG.info("Processing aborted by '%s'", func.__name__)

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -170,6 +170,19 @@ def get_scene_coverage(platform_name, start_time, end_time, sensor, area_id):
     return 100 * overpass.area_coverage(area_def)
 
 
+def check_platform(job):
+    """Check if the platform is valid.  If not, discard the scene."""
+    mda = job['input_mda']
+    product_list = job['product_list']
+    conf = get_config_value(product_list, '/common', 'processed_platforms')
+    if conf is None:
+        return
+    platform = mda['platform_name']
+    if platform not in conf:
+        raise AbortProcessing(
+            "'%s' not in list of allowed platforms" % platform)
+
+
 def plist_iter(product_list, base_mda=None, level=None):
     if base_mda is None:
         base_mda = {}

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -307,6 +307,22 @@ class TestCovers(unittest.TestCase):
         area_coverage.assert_called_with(6)
 
 
+class TestCheckPlatform(unittest.TestCase):
+
+    @mock.patch('trollflow2.get_config_value')
+    def test_check_platform(self, get_config_value):
+        from trollflow2 import check_platform
+        from trollflow2 import AbortProcessing
+        get_config_value.return_value = None
+        job = {'product_list': None, 'input_mda': {'platform_name': 'foo'}}
+        self.assertIsNone(check_platform(job))
+        get_config_value.return_value = ['foo', 'bar']
+        self.assertIsNone(check_platform(job))
+        get_config_value.return_value = ['bar']
+        with self.assertRaises(AbortProcessing):
+            check_platform(job)
+
+
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()
@@ -318,6 +334,7 @@ def suite():
     my_suite.addTest(loader.loadTestsFromTestCase(TestLoadComposites))
     my_suite.addTest(loader.loadTestsFromTestCase(TestResample))
     my_suite.addTest(loader.loadTestsFromTestCase(TestCovers))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestCheckPlatform))
 
     return my_suite
 


### PR DESCRIPTION
This PR adds a plugin that aborts processing of the scene if the platrom name isn't in the list of processed platforms.