### PR TITLE
Add a plugin to update input metadata with aliases

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -10,6 +10,14 @@ common:
       writer: geotiff
     - format: nc
       writer: cf
+  #metadata_aliases:
+  #  platform_name:
+  #    j01: NOAA-20
+  #    noaa15: NOAA-15
+  #    noaa18: NOAA-18
+  #    noaa19: NOAA-19
+  #  sensor:
+  #    avhrr/3: avhrr-3
 
 product_list: &product_list
   omerc_bb:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -170,6 +170,19 @@ def get_scene_coverage(platform_name, start_time, end_time, sensor, area_id):
     return 100 * overpass.area_coverage(area_def)
 
 
+def metadata_alias(job):
+    """Replace input metadata values with aliases"""
+    mda_out = job['input_mda'].copy()
+    product_list = job['product_list']
+    aliases = get_config_value(product_list, '/common', 'metadata_aliases')
+    if aliases is None:
+        return
+    for key in aliases:
+        if key in mda_out:
+            mda_out[key] = aliases[key].get(mda_out[key], mda_out[key])
+    job['input_mda'] = mda_out.copy()
+
+
 def plist_iter(product_list, base_mda=None, level=None):
     if base_mda is None:
         base_mda = {}

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -307,6 +307,28 @@ class TestCovers(unittest.TestCase):
         area_coverage.assert_called_with(6)
 
 
+class TestMetadataAlias(unittest.TestCase):
+
+    def test_metadata_alias(self):
+        from trollflow2 import metadata_alias
+        mda = {'platform_name': 'noaa15', 'not_changed': True}
+        product_list = {'common': {'not_metadata_aliases': True}}
+        job = {'input_mda': mda, 'product_list': product_list}
+        metadata_alias(job)
+        mda = job['input_mda']
+        self.assertEqual(mda['platform_name'], 'noaa15')
+        self.assertTrue(mda['not_changed'])
+        product_list = {'common': {'metadata_aliases':
+                                   {'platform_name': {'noaa15': 'NOAA-15'},
+                                    'not_in_mda': {'something': 'other'}}}}
+        job = {'input_mda': mda, 'product_list': product_list}
+        metadata_alias(job)
+        mda = job['input_mda']
+        self.assertEqual(mda['platform_name'], 'NOAA-15')
+        self.assertTrue(mda['not_changed'])
+        self.assertTrue('not_in_mda' not in mda)
+
+
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()
@@ -318,6 +340,7 @@ def suite():
     my_suite.addTest(loader.loadTestsFromTestCase(TestLoadComposites))
     my_suite.addTest(loader.loadTestsFromTestCase(TestResample))
     my_suite.addTest(loader.loadTestsFromTestCase(TestCovers))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestMetadataAlias))
 
     return my_suite
 


### PR DESCRIPTION
With this PR it's possible to replace input metadata values with aliases. This can be used e.g. to replace platform name with the OSCAR version and `AVHRR/3` sensor name to `avhrr-3` that SatPy understands.