### PR TITLE
Add Sun zenith angle filtering

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -20,6 +20,8 @@ common:
   #    noaa19: NOAA-19
   #  sensor:
   #    avhrr/3: avhrr-3
+  #sunzen_lon: 25.0
+  #sunzen_lat: 60.0
 
 product_list: &product_list
   omerc_bb:
@@ -35,12 +37,16 @@ product_list: &product_list
         formats:
           - format: nc
             writer: cf
+        # Remove product if SZA is more than this
+        #sunzen_day_maximum: 90.0
       ctth_alti:
         productname: ctth_alti
         output_dir: *output_dir
         formats:
           - format: nc
             writer: cf
+        # Remove product if SZA is less than this
+        #sunzen_night_minimum: 90.0
       cloudtype:
         productname: cloudtype
         output_dir: *output_dir

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -20,8 +20,8 @@ common:
   #    noaa19: NOAA-19
   #  sensor:
   #    avhrr/3: avhrr-3
-  #sunzen_lon: 25.0
-  #sunzen_lat: 60.0
+  #sunzen_check_lon: 25.0
+  #sunzen_check_lat: 60.0
 
 product_list: &product_list
   omerc_bb:
@@ -38,7 +38,7 @@ product_list: &product_list
           - format: nc
             writer: cf
         # Remove product if SZA is more than this
-        #sunzen_day_maximum: 90.0
+        #sunzen_maximum_angle: 90.0
       ctth_alti:
         productname: ctth_alti
         output_dir: *output_dir
@@ -46,7 +46,7 @@ product_list: &product_list
           - format: nc
             writer: cf
         # Remove product if SZA is less than this
-        #sunzen_night_minimum: 90.0
+        #sunzen_minimum_angle: 90.0
       cloudtype:
         productname: cloudtype
         output_dir: *output_dir

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ import sys
 
 install_requires = ['pyyaml', 'dpath', 'trollsift']
 if "test" not in sys.argv:
-    install_requires += ['posttroll', 'satpy']
+    install_requires += ['posttroll', 'satpy', 'pyorbital']
 
 setup(name="trollflow2",
       version=versioneer.get_version(),

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -208,10 +208,10 @@ def sza_check(job):
         products = list(product_list['product_list'][area]['products'].keys())
         for product in products:
             prod_path = "/product_list/%s/products/%s" % (area, product)
-            lon = get_config_value(product_list, prod_path, "sunzen_lon")
-            lat = get_config_value(product_list, prod_path, "sunzen_lat")
+            lon = get_config_value(product_list, prod_path, "sunzen_check_lon")
+            lat = get_config_value(product_list, prod_path, "sunzen_check_lat")
             if lon is None or lat is None:
-                LOG.debug("No 'sunzen_lon' or 'sunzen_lat' configured, "
+                LOG.debug("No 'sunzen_check_lon' or 'sunzen_check_lat' configured, "
                           "can\'t check Sun elevation for %s / %s",
                           area, product)
                 continue
@@ -220,7 +220,7 @@ def sza_check(job):
             LOG.debug("Sun zenith angle is %.2f degrees", sunzen)
             # Check nighttime limit
             limit = get_config_value(product_list, prod_path,
-                                     "sunzen_night_minimum")
+                                     "sunzen_minimum_angle")
             if limit is not None:
                 if sunzen < limit:
                     LOG.info("Sun zenith angle to small for nighttime "
@@ -230,7 +230,7 @@ def sza_check(job):
 
             # Check daytime limit
             limit = get_config_value(product_list, prod_path,
-                                     "sunzen_day_maximum")
+                                     "sunzen_maximum_angle")
             if limit is not None:
                 if sunzen > limit:
                     LOG.info("Sun zenith angle to large for daytime "

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -29,6 +29,7 @@ try:
     from satpy.resample import get_area_def
     from posttroll.message import Message
     from posttroll.publisher import NoisyPublisher
+    from pyorbital.astronomy import sun_zenith_angle
 except ImportError:
     Scene = None
     compute_writer_results = None
@@ -194,6 +195,51 @@ def metadata_alias(job):
         if key in mda_out:
             mda_out[key] = aliases[key].get(mda_out[key], mda_out[key])
     job['input_mda'] = mda_out.copy()
+
+
+def sza_check(job):
+    """Remove products which are not valid for the current Sun zenith angle."""
+    scn = job['scene']
+    start_time = scn.attrs['start_time']
+    product_list = job['product_list']
+    areas = list(product_list['product_list'].keys())
+    for area in areas:
+        products = list(product_list['product_list'][area]['products'].keys())
+        for product in products:
+            prod_path = "/product_list/%s/products/%s" % (area, product)
+            lon = get_config_value(product_list, prod_path, "sunzen_lon")
+            lat = get_config_value(product_list, prod_path, "sunzen_lat")
+            if lon is None or lat is None:
+                LOG.debug("No 'sunzen_lon' or 'sunzen_lat' configured, "
+                          "can\'t check Sun elevation for %s / %s",
+                          area, product)
+                continue
+
+            sunzen = sun_zenith_angle(start_time, lon, lat)
+            LOG.debug("Sun zenith angle is %.2f degrees", sunzen)
+            # Check nighttime limit
+            limit = get_config_value(product_list, prod_path,
+                                     "sunzen_night_minimum")
+            if limit is not None:
+                if sunzen < limit:
+                    LOG.info("Sun zenith angle to small for nighttime "
+                             "product '%s', product removed.", product)
+                    dpath.util.delete(product_list, prod_path)
+                continue
+
+            # Check daytime limit
+            limit = get_config_value(product_list, prod_path,
+                                     "sunzen_day_maximum")
+            if limit is not None:
+                if sunzen > limit:
+                    LOG.info("Sun zenith angle to large for daytime "
+                             "product '%s', product removed.", product)
+                    dpath.util.delete(product_list, prod_path)
+                continue
+
+        if len(product_list['product_list'][area]['products']) == 0:
+            LOG.info("Removing empty area: %s", area)
+            dpath.util.delete(product_list, '/product_list/%s' % area)
 
 
 def plist_iter(product_list, base_mda=None, level=None):

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -36,6 +36,7 @@ except ImportError:
     get_area_def = None
     Message = None
     NoisyPublisher = None
+    sun_zenith_angle = None
 
 try:
     from trollsched.satpass import Pass

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -373,6 +373,50 @@ class TestGetPluginConf(unittest.TestCase):
         self.assertEqual(res["val3"], "baz0")
 
 
+class TestSZACheck(unittest.TestCase):
+
+    @mock.patch("trollflow2.sun_zenith_angle")
+    def test_sza_check(self, sun_zenith_angle):
+        from trollflow2 import sza_check
+        job = {}
+        scene = mock.MagicMock()
+        scene.attrs = {'start_time': 42}
+        job['scene'] = scene
+        product_list = yaml.load(yaml_test1)
+        job['product_list'] = product_list.copy()
+        # Run without any settings
+        sza_check(job)
+        sun_zenith_angle.assert_not_called()
+
+        # Add SZA limits to couple of products
+        # Day product
+        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_day_maximum'] = 95.
+        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_lon'] = 25.
+        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_lat'] = 60.
+        # Night product
+        product_list['product_list']['germ']['products']['cloudtype']['sunzen_night_minimum'] = 85.
+        product_list['product_list']['germ']['products']['cloudtype']['sunzen_lon'] = 25.
+        product_list['product_list']['germ']['products']['cloudtype']['sunzen_lat'] = 60.
+
+        # Zenith angle that removes nothing
+        sun_zenith_angle.return_value = 90.
+        sza_check(job)
+        sun_zenith_angle.assert_called_with(42, 25., 60.)
+        self.assertDictEqual(job['product_list'], product_list)
+
+        # Zenith angle that removes day products
+        sun_zenith_angle.return_value = 100.
+        sza_check(job)
+        self.assertTrue('cloud_top_height' in product_list['product_list']['omerc_bb']['products'])
+        self.assertFalse('ct' in product_list['product_list']['omerc_bb']['products'])
+
+        # Zenith angle that removes night products
+        sun_zenith_angle.return_value = 45.
+        sza_check(job)
+        # There was only one product, so the whole area is deleted
+        self.assertFalse('germ' in job['product_list']['product_list'])
+
+
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()
@@ -386,6 +430,7 @@ def suite():
     my_suite.addTest(loader.loadTestsFromTestCase(TestCovers))
     my_suite.addTest(loader.loadTestsFromTestCase(TestMetadataAlias))
     my_suite.addTest(loader.loadTestsFromTestCase(TestGetPluginConf))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestSZACheck))
 
     return my_suite
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -390,13 +390,13 @@ class TestSZACheck(unittest.TestCase):
 
         # Add SZA limits to couple of products
         # Day product
-        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_day_maximum'] = 95.
-        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_lon'] = 25.
-        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_lat'] = 60.
+        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_maximum_angle'] = 95.
+        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_check_lon'] = 25.
+        product_list['product_list']['omerc_bb']['products']['ct']['sunzen_check_lat'] = 60.
         # Night product
-        product_list['product_list']['germ']['products']['cloudtype']['sunzen_night_minimum'] = 85.
-        product_list['product_list']['germ']['products']['cloudtype']['sunzen_lon'] = 25.
-        product_list['product_list']['germ']['products']['cloudtype']['sunzen_lat'] = 60.
+        product_list['product_list']['germ']['products']['cloudtype']['sunzen_minimum_angle'] = 85.
+        product_list['product_list']['germ']['products']['cloudtype']['sunzen_check_lon'] = 25.
+        product_list['product_list']['germ']['products']['cloudtype']['sunzen_check_lat'] = 60.
 
         # Zenith angle that removes nothing
         sun_zenith_angle.return_value = 90.


### PR DESCRIPTION
This PR makes it possible to define minimum and maximum Sun zenith angles (SZA) for each product:
- Set `sunzen_check_lon` and `sunzen_check_lat` to define the location where to check the SZA
- Set `sunzen_maximum_angle` for daytime product to tell the maximum allowed SZA
- Set `sunzen_minimum_angle` for nighttime product to tell the minimum required SZA

The settings can be either at:
- `product` level to control settings for individual product
- `area` level to have the settings for all the products in that area group
- in `common` to have global settings for each area and product