### PR TITLE
Add support for products in satellite projection

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -63,9 +63,8 @@ product_list: &product_list
         formats:
           - format: tif
             writer: geotiff
-
-  # euron1:
-  #   areaname: euron1
+  # null:  # satellite projection
+  #   areaname: satellite_projection
   #   products:
   #     cloudtype:
   #       productname: cloudtype

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -83,7 +83,7 @@ def resample(job):
     job['resampled_scenes'] = {}
     scn = job['scene']
     for area in product_list['product_list']:
-        area_conf = _get_plugin_conf(product_list, '/product_list/' + area,
+        area_conf = _get_plugin_conf(product_list, '/product_list/' + str(area),
                                      conf)
         LOG.info('Resampling to %s', str(area))
         if area is None:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -86,7 +86,10 @@ def resample(job):
         area_conf = _get_plugin_conf(product_list, '/product_list/' + area,
                                      conf)
         LOG.info('Resampling to %s', str(area))
-        job['resampled_scenes'][area] = scn.resample(area, **area_conf)
+        if area is None:
+            job['resampled_scenes'][area] = scn
+        else:
+            job['resampled_scenes'][area] = scn.resample(area, **area_conf)
 
 
 def save_datasets(job):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -120,10 +120,12 @@ def expand(yml):
                 yml[key] = copy.deepcopy(yml[key])
     return yml
 
+
 def process(msg, prod_list):
     try:
         with open(prod_list) as fd:
             config = yaml.load(fd.read())
+        config = expand(config)
         jobs = message_to_jobs(msg, config)
         for prio in sorted(jobs.keys()):
             job = jobs[prio]

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -286,8 +286,8 @@ class TestResample(unittest.TestCase):
         scn = mock.MagicMock()
         scn.resample.return_value = "foo"
         job = {"scene": scn, "product_list": self.product_list.copy()}
-        job['product_list'][None] = job['product_list']['germ']
-        del job['product_list']['germ']
+        job['product_list']['product_list'][None] = job['product_list']['product_list']['germ']
+        del job['product_list']['product_list']['germ']
         resample(job)
         self.assertTrue(mock.call('omerc_bb',
                                   radius_of_influence=None,

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -299,22 +299,12 @@ class TestResample(unittest.TestCase):
                                   resampler="nearest",
                                   reduce_data=True) in
                         scn.resample.mock_calls)
-        self.assertTrue(scn in job['resampled_scenes'])
+        self.assertTrue(job['resampled_scenes'][None] is scn)
         self.assertTrue("resampled_scenes" in job)
-        for area in ["omerc_bb", None, "euron1"]:
+        for area in ["omerc_bb", "euron1"]:
             self.assertTrue(area in job["resampled_scenes"])
             self.assertTrue(job["resampled_scenes"][area] == "foo")
 
-        prod_list = self.product_list.copy()
-        prod_list["common"] = {"resampler": "bilinear"}
-        prod_list["product_list"]["euron1"]["reduce_data"] = False
-        job = {"product_list": prod_list, "scene": scn}
-        resample(job)
-        self.assertTrue(mock.call('euron1',
-                                  radius_of_influence=None,
-                                  resampler="bilinear",
-                                  reduce_data=False) in
-                        scn.resample.mock_calls)
 
 
 class TestCovers(unittest.TestCase):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -281,6 +281,41 @@ class TestResample(unittest.TestCase):
                                   reduce_data=False) in
                         scn.resample.mock_calls)
 
+    def test_resample_satproj(self):
+        from trollflow2 import resample
+        scn = mock.MagicMock()
+        scn.resample.return_value = "foo"
+        job = {"scene": scn, "product_list": self.product_list.copy()}
+        job['product_list'][None] = job['product_list']['germ']
+        del job['product_list']['germ']
+        resample(job)
+        self.assertTrue(mock.call('omerc_bb',
+                                  radius_of_influence=None,
+                                  resampler="nearest",
+                                  reduce_data=True) in
+                        scn.resample.mock_calls)
+        self.assertTrue(mock.call('euron1',
+                                  radius_of_influence=None,
+                                  resampler="nearest",
+                                  reduce_data=True) in
+                        scn.resample.mock_calls)
+        self.assertTrue(scn in job['resampled_scenes'])
+        self.assertTrue("resampled_scenes" in job)
+        for area in ["omerc_bb", None, "euron1"]:
+            self.assertTrue(area in job["resampled_scenes"])
+            self.assertTrue(job["resampled_scenes"][area] == "foo")
+
+        prod_list = self.product_list.copy()
+        prod_list["common"] = {"resampler": "bilinear"}
+        prod_list["product_list"]["euron1"]["reduce_data"] = False
+        job = {"product_list": prod_list, "scene": scn}
+        resample(job)
+        self.assertTrue(mock.call('euron1',
+                                  radius_of_influence=None,
+                                  resampler="bilinear",
+                                  reduce_data=False) in
+                        scn.resample.mock_calls)
+
 
 class TestCovers(unittest.TestCase):
 


### PR DESCRIPTION
This PR adds support for the `null` area, representing data in satellite projection (that is data that will not be resampled).