### PR TITLE
Expose more kwargs for scn.resample()

### DIFF
--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -90,7 +90,20 @@ def resample(job):
                                      conf)
         LOG.info('Resampling to %s', str(area))
         if area is None:
-            job['resampled_scenes'][area] = scn
+            minarea = get_config_value(product_list,
+                                       '/product_list/' + str(area),
+                                       'use_min_area')
+            maxarea = get_config_value(product_list,
+                                       '/product_list/' + str(area),
+                                       'use_max_area')
+            if minarea is True:
+                job['resampled_scenes'][area] = scn.resample(scn.min_area(),
+                                                             **area_conf)
+            elif maxarea is True:
+                job['resampled_scenes'][area] = scn.resample(scn.max_area(),
+                                                             **area_conf)
+            else:
+                job['resampled_scenes'][area] = scn
         else:
             job['resampled_scenes'][area] = scn.resample(area, **area_conf)
 

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -77,7 +77,10 @@ def load_composites(job):
 def resample(job):
     defaults = {"radius_of_influence": None,
                 "resampler": "nearest",
-                "reduce_data": True}
+                "reduce_data": True,
+                "cache_dir": None,
+                "mask_area": False,
+                "epsilon": 0.0}
     product_list = job['product_list']
     conf = _get_plugin_conf(product_list, '/common', defaults)
     job['resampled_scenes'] = {}

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -253,17 +253,26 @@ class TestResample(unittest.TestCase):
         self.assertTrue(mock.call('omerc_bb',
                                   radius_of_influence=None,
                                   resampler="nearest",
-                                  reduce_data=True) in
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
                         scn.resample.mock_calls)
         self.assertTrue(mock.call('germ',
                                   radius_of_influence=None,
                                   resampler="nearest",
-                                  reduce_data=True) in
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
                         scn.resample.mock_calls)
         self.assertTrue(mock.call('euron1',
                                   radius_of_influence=None,
                                   resampler="nearest",
-                                  reduce_data=True) in
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
                         scn.resample.mock_calls)
         self.assertTrue("resampled_scenes" in job)
         for area in ["omerc_bb", "germ", "euron1"]:
@@ -278,7 +287,10 @@ class TestResample(unittest.TestCase):
         self.assertTrue(mock.call('euron1',
                                   radius_of_influence=None,
                                   resampler="bilinear",
-                                  reduce_data=False) in
+                                  reduce_data=False,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
                         scn.resample.mock_calls)
 
     def test_resample_satproj(self):
@@ -292,12 +304,18 @@ class TestResample(unittest.TestCase):
         self.assertTrue(mock.call('omerc_bb',
                                   radius_of_influence=None,
                                   resampler="nearest",
-                                  reduce_data=True) in
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
                         scn.resample.mock_calls)
         self.assertTrue(mock.call('euron1',
                                   radius_of_influence=None,
                                   resampler="nearest",
-                                  reduce_data=True) in
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
                         scn.resample.mock_calls)
         self.assertTrue(job['resampled_scenes'][None] is scn)
         self.assertTrue("resampled_scenes" in job)

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -323,6 +323,38 @@ class TestResample(unittest.TestCase):
             self.assertTrue(area in job["resampled_scenes"])
             self.assertTrue(job["resampled_scenes"][area] == "foo")
 
+    def test_minmax_area(self):
+        from trollflow2 import resample
+        scn = mock.MagicMock()
+        scn.resample.return_value = "foo"
+        product_list = self.product_list.copy()
+        product_list['product_list'][None] = product_list['product_list']['germ']
+        product_list['product_list'][None]['use_min_area'] = True
+        del product_list['product_list']['germ']
+        del product_list['product_list']['omerc_bb']
+        del product_list['product_list']['euron1']
+        job = {"scene": scn, "product_list": product_list.copy()}
+        resample(job)
+        self.assertTrue(mock.call(scn.min_area(),
+                                  radius_of_influence=None,
+                                  resampler="nearest",
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
+                        scn.resample.mock_calls)
+        del product_list['product_list'][None]['use_min_area']
+        product_list['product_list'][None]['use_max_area'] = True
+        job = {"scene": scn, "product_list": product_list.copy()}
+        resample(job)
+        self.assertTrue(mock.call(scn.max_area(),
+                                  radius_of_influence=None,
+                                  resampler="nearest",
+                                  reduce_data=True,
+                                  cache_dir=None,
+                                  mask_area=False,
+                                  epsilon=0.0) in
+                        scn.resample.mock_calls)
 
 
 class TestCovers(unittest.TestCase):


### PR DESCRIPTION
This PR exposes three more keyword arguments for `scn.resample()`:
- `cache_dir`: store resampling look-up-tables to this directory (default: `None`, don't save them)
- `mask_area`: force masking for invalid data locations (default: `False`, don't mask data)
- `epsilon`: allowed resampling uncertainty in meters (default: `0`)
Also adds a possibility to use `use_min_area` and `use_max_area` to do the equivalent of `scn.resample(scn.min_area())` and `scn.resampler(scn.max_area())`