### PR TITLE
Make it possible to delay composite creation

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -23,6 +23,10 @@ common:
   #    avhrr/3: avhrr-3
   #sunzen_check_lon: 25.0
   #sunzen_check_lat: 60.0
+  # Set delay_composites to `False` to create composites before resampling.
+  #   Default is to create them after resampling (`True`), which is much
+  #   faster in most cases
+  # delay_composites: False
 
 product_list: &product_list
   omerc_bb:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -72,7 +72,8 @@ def load_composites(job):
     LOG.info('Loading %s', str(composites))
     scn = job['scene']
     resolution = job['product_list']['common'].get('resolution', None)
-    scn.load(composites, resolution=resolution)
+    generate = job['product_list']['common'].get('delay_composites', True) is False
+    scn.load(composites, resolution=resolution, generate=generate)
     job['scene'] = scn
 
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -236,15 +236,16 @@ class TestLoadComposites(unittest.TestCase):
         scn = mock.MagicMock()
         job = {"product_list": self.product_list, "scene": scn}
         load_composites(job)
-        scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'}, resolution=None)
+        scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'}, resolution=None, generate=False)
 
-    def test_load_composites_with_resolution(self):
+    def test_load_composites_with_config(self):
         from trollflow2 import load_composites
         scn = mock.MagicMock()
         self.product_list['common']['resolution'] = 1000
+        self.product_list['common']['delay_composites'] = False
         job = {"product_list": self.product_list, "scene": scn}
         load_composites(job)
-        scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'}, resolution=1000)
+        scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'}, resolution=1000, generate=True)
 
 
 class TestResample(unittest.TestCase):


### PR DESCRIPTION
This PR makes it possible to delay composite creation until after resampling. In most cases this is much faster, and is thus is now the default behaviour. To create composites _before_ resampling the user can set `delay_composites: False` in the `common` section of the production config file.

As an example, 5-area 55-product product list with bilinear interpolation and pre-computed resampling LUTs the processing times (with a single core) are:
- `delay_composites: False`: 35 minutes
- `delay_composites: True`: 5 minutes