### PR TITLE
Fix compatibility issues caused by changes introduced in pyyaml 5.1

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -28,7 +28,10 @@ except ImportError:
     ListenerContainer = None
 from six.moves.queue import Empty as queue_empty
 from multiprocessing import Process
-import yaml
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 import time
 from trollflow2 import gen_dict_extract, plist_iter
 from collections import OrderedDict
@@ -124,7 +127,7 @@ def expand(yml):
 def process(msg, prod_list):
     try:
         with open(prod_list) as fd:
-            config = yaml.load(fd.read())
+            config = yaml.load(fd.read(), Loader=UnsafeLoader)
         config = expand(config)
         jobs = message_to_jobs(msg, config)
         for prio in sorted(jobs.keys()):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -28,6 +28,7 @@ except ImportError:
     ListenerContainer = None
 from six.moves.queue import Empty as queue_empty
 from multiprocessing import Process
+import yaml
 try:
     from yaml import UnsafeLoader
 except ImportError:


### PR DESCRIPTION
Pyyaml 5.1 changed default behaviour of `yaml.load()` so that automatic imports using `!!python/name:package.module.function` don't work anymor. This PR adds a fix and backwards compatibility for the changes.

More info: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation