### PR TITLE
Make publish topic composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # trollflow2
 Next gen trollflow
+
+Trollflow2 supports only Python 3.4 and newer.

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,6 @@ setup(name="trollflow2",
       zip_safe=False,
       install_requires=install_requires,
       tests_require=['mock'],
+      python_requires='>=3.4',
       test_suite='trollflow2.tests.suite',
       )

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -150,14 +150,19 @@ class FilePublisher(object):
         mda = job['input_mda'].copy()
         mda.pop('dataset', None)
         mda.pop('collection', None)
-        topic = job['product_list']['common']['publish_topic']
         for fmat, fmat_config in plist_iter(job['product_list']['product_list']):
+            prod_path = "/product_list/%s/%s" % (fmat['area'], fmat['product'])
+            topic_pattern = get_config_value(job['product_list'],
+                                             prod_path,
+                                             "publish_topic")
+
             file_mda = mda.copy()
             try:
                 file_mda['uri'] = fmat['filename']
             except KeyError:
                 continue
             file_mda['uid'] = os.path.basename(fmat['filename'])
+            topic = compose(topic_pattern, fmat)
             msg = Message(topic, 'file', file_mda)
             LOG.debug('Publishing %s', str(msg))
             self.pub.send(str(msg))

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -24,6 +24,10 @@
 import unittest
 import yaml
 try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
+try:
     from unittest import mock
 except ImportError:
     import mock
@@ -112,7 +116,7 @@ class TestGetAreaPriorities(unittest.TestCase):
 
     def test_get_area_priorities(self):
         from trollflow2.launcher import get_area_priorities
-        prodlist = yaml.load(yaml_test1)
+        prodlist = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
         priorities = get_area_priorities(prodlist)
         self.assertTrue(1 in priorities)
@@ -128,7 +132,7 @@ class TestMessageToJobs(unittest.TestCase):
 
     def test_message_to_jobs(self):
         from trollflow2.launcher import message_to_jobs
-        prodlist = yaml.load(yaml_test1)
+        prodlist = yaml.load(yaml_test1, Loader=UnsafeLoader)
         msg = mock.MagicMock()
         msg.data = {'uri': 'foo'}
 
@@ -152,7 +156,7 @@ class TestMessageToJobs(unittest.TestCase):
 
     def test_message_to_jobs_minimal(self):
         from trollflow2.launcher import message_to_jobs
-        prodlist = yaml.load(yaml_test_minimal)
+        prodlist = yaml.load(yaml_test_minimal, Loader=UnsafeLoader)
         msg = mock.MagicMock()
         msg.data = {'uri': 'foo'}
         jobs = message_to_jobs(msg, prodlist)

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -24,6 +24,10 @@
 import unittest
 import yaml
 try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
+try:
     from unittest import mock
 except ImportError:
     import mock
@@ -153,7 +157,7 @@ class TestProdList(unittest.TestCase):
 
     def test_iter(self):
         from trollflow2 import plist_iter
-        prodlist = yaml.load(yaml_test1)['product_list']
+        prodlist = yaml.load(yaml_test1, Loader=UnsafeLoader)['product_list']
         expected = [{'areaname': 'euron1_in_fname', 'area': 'euron1', 'productname': 'cloud_top_height_in_fname', 'product': 'cloud_top_height',
                      'min_coverage': 20.0,
                      'output_dir': '/tmp/satdmz/pps/www/latest_2018/', 'format': 'png', 'writer': 'simple_image',
@@ -173,7 +177,7 @@ class TestProdList(unittest.TestCase):
                      'writer': 'geotiff'}]
         for i, exp in zip(plist_iter(prodlist), expected):
             self.assertDictEqual(i[0], exp)
-        prodlist = yaml.load(yaml_test2)['product_list']
+        prodlist = yaml.load(yaml_test2, Loader=UnsafeLoader)['product_list']
         for i, exp in zip(plist_iter(prodlist), expected):
             self.assertDictEqual(i[0], exp)
 
@@ -185,8 +189,8 @@ class TestSaveDatasets(unittest.TestCase):
         job = {}
         job['input_mda'] = input_mda
         job['product_list'] = {
-            'product_list': yaml.load(yaml_test1)['product_list'],
-            'common': yaml.load(yaml_common)['common'],
+            'product_list': yaml.load(yaml_test1, Loader=UnsafeLoader)['product_list'],
+            'common': yaml.load(yaml_common, Loader=UnsafeLoader)['common'],
         }
         job['resampled_scenes'] = {}
         for area in job['product_list']['product_list']:
@@ -227,7 +231,7 @@ class TestSaveDatasets(unittest.TestCase):
 class TestConfigValue(unittest.TestCase):
 
     def setUp(self):
-        self.prodlist = yaml.load(yaml_test1)
+        self.prodlist = yaml.load(yaml_test1, Loader=UnsafeLoader)
         self.path = "/product_list/germ/products/cloudtype"
 
     def test_config_value_same_level(self):
@@ -281,7 +285,7 @@ class TestCreateScene(unittest.TestCase):
 class TestLoadComposites(unittest.TestCase):
 
     def setUp(self):
-        self.product_list = yaml.load(yaml_test1)
+        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
     def test_load_composites(self):
         from trollflow2 import load_composites
@@ -303,7 +307,7 @@ class TestLoadComposites(unittest.TestCase):
 class TestResample(unittest.TestCase):
 
     def setUp(self):
-        self.product_list = yaml.load(yaml_test1)
+        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
     def test_resample(self):
         from trollflow2 import resample
@@ -421,7 +425,7 @@ class TestResample(unittest.TestCase):
 class TestCovers(unittest.TestCase):
 
     def setUp(self):
-        self.product_list = yaml.load(yaml_test1)
+        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
                           "start_time": dt.datetime(2019, 1, 19, 11),
@@ -534,7 +538,7 @@ class TestSZACheck(unittest.TestCase):
         scene = mock.MagicMock()
         scene.attrs = {'start_time': 42}
         job['scene'] = scene
-        product_list = yaml.load(yaml_test1)
+        product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
         job['product_list'] = product_list.copy()
         # Run without any settings
         sza_check(job)


### PR DESCRIPTION
This PR makes it possible to use `trollsift` patterns in the publisher topics. All the keys in passed to the message can be used.