### PR TITLE
Check `collection_area_id` in the input metadata

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -27,6 +27,9 @@ common:
   #   Default is to create them after resampling (`True`), which is much
   #   faster in most cases
   # delay_composites: False
+  # Check area coverage by `collection_area_id` in the input metadata.
+  #   Default: False
+  # coverage_by_collection_area: True
 
 product_list: &product_list
   omerc_bb:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -173,7 +173,9 @@ def covers(job):
         LOG.info("Keeping all areas")
         return
 
-    if 'collection_area_id' in job['input_mda']:
+    col_area = job['product_list']['common'].get('coverage_by_collection_area',
+                                                 False)
+    if col_area and 'collection_area_id' in job['input_mda']:
         if job['input_mda']['collection_area_id'] not in job['product_list']['product_list']:
             raise AbortProcessing(
                 "Area collection ID '%s' does not match "

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -173,6 +173,13 @@ def covers(job):
         LOG.info("Keeping all areas")
         return
 
+    if 'collection_area_id' in job['input_mda']:
+        if job['input_mda']['collection_area_id'] not in job['product_list']['product_list']:
+            raise AbortProcessing(
+                "Area collection ID '%s' does not match "
+                "production area(s) %s" % (job['input_mda']['collection_area_id'],
+                                        str(list(job['product_list']['product_list']))))
+
     product_list = job['product_list'].copy()
 
     scn_mda = job['scene'].attrs.copy()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -134,10 +134,11 @@ def process(msg, prod_list):
         for prio in sorted(jobs.keys()):
             job = jobs[prio]
             job['processing_priority'] = prio
-            for wrk in config['workers']:
-                cwrk = wrk.copy()
-                cwrk.pop('fun')(job, **cwrk)
-    except AbortProcessing as err:
-        LOG.info(str(err))
+            try:
+                for wrk in config['workers']:
+                    cwrk = wrk.copy()
+                    cwrk.pop('fun')(job, **cwrk)
+            except AbortProcessing as err:
+                LOG.info(str(err))
     except Exception:
         LOG.exception("Process crashed")

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -469,6 +469,25 @@ class TestCovers(unittest.TestCase):
         get_area_def.assert_called_with(5)
         area_coverage.assert_called_with(6)
 
+    @mock.patch('trollflow2.get_scene_coverage')
+    @mock.patch('trollflow2.Pass')
+    def test_covers_collection_area_id(self, ts_pass, get_scene_coverage):
+        from trollflow2 import covers
+        from trollflow2 import AbortProcessing
+        get_scene_coverage.return_value = 100.0
+        scn = mock.MagicMock()
+        scn.attrs = {}
+        job = {"product_list": self.product_list,
+               "input_mda": self.input_mda,
+               "scene": scn}
+        job['input_mda']['collection_area_id'] = 'euron1'
+        # Nothing should happen here
+        covers(job)
+        # Area not in the product list should raise AbortProcessing
+        job['input_mda']['collection_area_id'] = 'not_in_pl'
+        with self.assertRaises(AbortProcessing):
+            covers(job)
+
 
 class TestCheckPlatform(unittest.TestCase):
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -485,8 +485,12 @@ class TestCovers(unittest.TestCase):
         # Area that matches the product list, nothing should happen
         job['input_mda']['collection_area_id'] = 'euron1'
         covers(job)
-        # Area not in the product list should raise AbortProcessing
+        # By default collection_area_id isn't checked so nothing should happen
         job['input_mda']['collection_area_id'] = 'not_in_pl'
+        covers(job)
+        # Turn coverage check on, so area not in the product list should raise
+        # AbortProcessing
+        job['product_list']['common']['coverage_by_collection_area'] = True
         with self.assertRaises(AbortProcessing):
             covers(job)
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -480,8 +480,10 @@ class TestCovers(unittest.TestCase):
         job = {"product_list": self.product_list,
                "input_mda": self.input_mda,
                "scene": scn}
-        job['input_mda']['collection_area_id'] = 'euron1'
         # Nothing should happen here
+        covers(job)
+        # Area that matches the product list, nothing should happen
+        job['input_mda']['collection_area_id'] = 'euron1'
         covers(job)
         # Area not in the product list should raise AbortProcessing
         job['input_mda']['collection_area_id'] = 'not_in_pl'


### PR DESCRIPTION
This PR adds a check that `collection_area_id`, if exists, in input metadata matches the areas in the product list. This is useful when polar data are collected using `gatherer.py`. With this the collections are processed only for the proper areas. For best effect all the areas should have different priorities.