### PR TITLE
Add a possibility to send emails about crashes

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -31,12 +31,6 @@ common:
   #   faster in most cases
   # delay_composites: False
   # Send emails about crashes using sendmail
-  #crash_email_settings:
-  #  from: "user@server"
-  #  to: "user@institute"
-  #  subject: "Crash report"
-  #  header: "Header text before the error message"
-  #  sendmail: "/usr/sbin/sendmail"
   # Check area coverage by `collection_area_id` in the input metadata.
   #   Default: False
   # coverage_by_collection_area: True
@@ -150,3 +144,15 @@ workers:
   - fun: !!python/name:trollflow2.resample
   - fun: !!python/name:trollflow2.save_datasets
   - fun: !!python/object:trollflow2.FilePublisher {}
+
+# Things to run in case of a crash
+#crash_handlers:
+#  config:
+#    sendmail:
+#      from: "user@server"
+#        to: "user@institute"
+#        subject: "Crash report"
+#        header: "Header text before the error message"
+#        sendmail: "/usr/sbin/sendmail"
+#  handlers:
+#    - fun: !!python/name:trollflow2.launcher.sendmail

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -27,6 +27,13 @@ common:
   #   Default is to create them after resampling (`True`), which is much
   #   faster in most cases
   # delay_composites: False
+  # Send emails about crashes using sendmail
+  #crash_email_settings:
+  #  from: "user@server"
+  #  to: "user@institute"
+  #  subject: "Crash report"
+  #  header: "Header text before the error message"
+  #  sendmail: "/usr/sbin/sendmail"
 
 product_list: &product_list
   omerc_bb:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -129,7 +129,7 @@ def save_datasets(job):
         filename = compose(os.path.join(fmat['output_dir'], fname_pattern), fmat)
         fmat.pop('format', None)
         try:
-            objs.append(scns[fmat['area']].save_dataset(fmat['product'], filename=filename, compute=False, **fmat))
+            objs.append(scns[fmat['area']].save_dataset(fmat['product'], compute=False, **fmat))
         except KeyError as err:
             LOG.info('Skipping %s: %s', fmat['productname'], str(err))
         else:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -123,6 +123,7 @@ def save_datasets(job):
     base_config = job['input_mda'].copy()
     base_config.update(job['product_list']['common'])
     base_config.pop('dataset', None)
+    base_config.pop('filenam', None)
 
     for fmat, fmat_config in plist_iter(job['product_list']['product_list'], base_config):
         fname_pattern = fmat['fname_pattern']

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -128,7 +128,7 @@ def save_datasets(job):
         fname_pattern = fmat['fname_pattern']
         filename = compose(os.path.join(fmat['output_dir'], fname_pattern), fmat)
         fmat.pop('format', None)
-        base_config.pop('filename', None)
+        fmat.pop('filename', None)
         try:
             objs.append(scns[fmat['area']].save_dataset(fmat['product'],
                                                         filename=filename,

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -123,12 +123,12 @@ def save_datasets(job):
     base_config = job['input_mda'].copy()
     base_config.update(job['product_list']['common'])
     base_config.pop('dataset', None)
-    base_config.pop('filename', None)
 
     for fmat, fmat_config in plist_iter(job['product_list']['product_list'], base_config):
         fname_pattern = fmat['fname_pattern']
         filename = compose(os.path.join(fmat['output_dir'], fname_pattern), fmat)
         fmat.pop('format', None)
+        base_config.pop('filename', None)
         try:
             objs.append(scns[fmat['area']].save_dataset(fmat['product'],
                                                         filename=filename,

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -129,7 +129,9 @@ def save_datasets(job):
         filename = compose(os.path.join(fmat['output_dir'], fname_pattern), fmat)
         fmat.pop('format', None)
         try:
-            objs.append(scns[fmat['area']].save_dataset(fmat['product'], compute=False, **fmat))
+            objs.append(scns[fmat['area']].save_dataset(fmat['product'],
+                                                        filename=filename,
+                                                        compute=False, **fmat))
         except KeyError as err:
             LOG.info('Skipping %s: %s', fmat['productname'], str(err))
         else:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -123,7 +123,7 @@ def save_datasets(job):
     base_config = job['input_mda'].copy()
     base_config.update(job['product_list']['common'])
     base_config.pop('dataset', None)
-    base_config.pop('filenam', None)
+    base_config.pop('filename', None)
 
     for fmat, fmat_config in plist_iter(job['product_list']['product_list'], base_config):
         fname_pattern = fmat['fname_pattern']

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -148,19 +148,19 @@ def process(msg, prod_list):
                 LOG.info(str(err))
     except Exception:
         LOG.exception("Process crashed")
-        if "crash_email_settings" in config['common']:
+        if "crash_handlers" in config:
             trace = traceback.format_exc()
-            email_crash(config['common']['crash_email_settings'], err, trace)
-            LOG.info("Sent email about the crash.")
+            for hand in config['crash_handlers']['handlers']:
+                hand['fun'](config['crash_handlers']['config'], trace)
 
 
-def email_crash(email_settings, error, trace):
-    """Send email about crashes"""
+def sendmail(config, trace):
+    """Send email about crashes using `sendmail`"""
     from email.mime.text import MIMEText
     from subprocess import Popen, PIPE
 
-    msg = MIMEText(email_settings["header"] + "\n\n" + str(error) +
-                   "\n\n" + trace)
+    email_settings = config['email']
+    msg = MIMEText(email_settings["header"] + "\n\n" + "\n\n" + trace)
     msg["From"] = email_settings["from"]
     msg["To"] = email_settings["to"]
     msg["Subject"] = email_settings["subject"]

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -139,10 +139,10 @@ def process(msg, prod_list):
                 cwrk.pop('fun')(job, **cwrk)
     except AbortProcessing as err:
         LOG.info(str(err))
-    except Exception:
+    except Exception as err:
         LOG.exception("Process crashed")
         if "crash_email_settings" in config['common']:
-            email_crash(config['common']['crash_email_settings'])
+            email_crash(config['common']['crash_email_settings'], err)
             LOG.info("Sent email about the crash.")
 
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -151,7 +151,7 @@ def email_crash(email_settings, error):
     from email.mime.text import MIMEText
     from subprocess import Popen, PIPE
 
-    msg = MIMEText(email_settings["header"] + "\n\n" + error)
+    msg = MIMEText(email_settings["header"] + "\n\n" + str(error))
     msg["From"] = email_settings["from"]
     msg["To"] = email_settings["to"]
     msg["Subject"] = email_settings["subject"]

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -141,3 +141,22 @@ def process(msg, prod_list):
         LOG.info(str(err))
     except Exception:
         LOG.exception("Process crashed")
+        if "crash_email_settings" in config['common']:
+            email_crash(config['common']['crash_email_settings'])
+            LOG.info("Sent email about the crash.")
+
+
+def email_crash(email_settings, error):
+    """Send email about crashes"""
+    from email.mime.text import MIMEText
+    from subprocess import Popen, PIPE
+
+    msg = MIMEText(email_settings["header"] + "\n\n" + error)
+    msg["From"] = email_settings["from"]
+    msg["To"] = email_settings["to"]
+    msg["Subject"] = email_settings["subject"]
+    sendmail = email_settings.get("sendmail", "/usr/bin/sendmail")
+
+    pid = Popen([sendmail, "-t", "-oi"], stdin=PIPE)
+    pid.communicate(msg.as_bytes())
+    pid.terminate()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -38,6 +38,7 @@ from trollflow2 import gen_dict_extract, plist_iter, AbortProcessing
 from collections import OrderedDict
 import copy
 from six.moves.urllib.parse import urlparse
+import traceback
 
 """The order of basic things is:
 - Create the scene
@@ -142,16 +143,18 @@ def process(msg, prod_list):
     except Exception as err:
         LOG.exception("Process crashed")
         if "crash_email_settings" in config['common']:
-            email_crash(config['common']['crash_email_settings'], err)
+            trace = traceback.format_exc()
+            email_crash(config['common']['crash_email_settings'], err, trace)
             LOG.info("Sent email about the crash.")
 
 
-def email_crash(email_settings, error):
+def email_crash(email_settings, error, trace):
     """Send email about crashes"""
     from email.mime.text import MIMEText
     from subprocess import Popen, PIPE
 
-    msg = MIMEText(email_settings["header"] + "\n\n" + str(error))
+    msg = MIMEText(email_settings["header"] + "\n\n" + str(error) +
+                   "\n\n" + trace)
     msg["From"] = email_settings["from"]
     msg["To"] = email_settings["to"]
     msg["Subject"] = email_settings["subject"]

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -30,10 +30,10 @@ from six.moves.queue import Empty as queue_empty
 from multiprocessing import Process
 import yaml
 try:
-    from yaml import UnsafeLoader, SafeLoader
+    from yaml import UnsafeLoader, BaseLoader
 except ImportError:
     from yaml import Loader as UnsafeLoader
-    from yaml import SafeLoader
+    from yaml import BaseLoader
 import time
 from trollflow2 import gen_dict_extract, plist_iter, AbortProcessing
 from collections import OrderedDict
@@ -55,7 +55,7 @@ DEFAULT_PRIORITY = 999
 def run(prod_list, topics=None):
 
     with open(prod_list) as fid:
-        config = yaml.load(fid.read(), Loader=SafeLoader)
+        config = yaml.load(fid.read(), Loader=BaseLoader)
     topics = topics or config['common'].pop('subscribe_topics', None)
 
     listener = ListenerContainer(topics=topics)

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -159,7 +159,7 @@ def sendmail(config, trace):
     from email.mime.text import MIMEText
     from subprocess import Popen, PIPE
 
-    email_settings = config['email']
+    email_settings = config['sendmail']
     msg = MIMEText(email_settings["header"] + "\n\n" + "\n\n" + trace)
     msg["From"] = email_settings["from"]
     msg["To"] = email_settings["to"]


### PR DESCRIPTION
As Trollflow2 handles crashes internally, `supervisord` don't report anything about them, and only trace of the problem is in the log files. This PR adds a possibility to send emails with the error message.