### PR TITLE
Handle aliases for iterable metadata values

### DIFF
--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -252,7 +252,13 @@ def metadata_alias(job):
         return
     for key in aliases:
         if key in mda_out:
-            mda_out[key] = aliases[key].get(mda_out[key], mda_out[key])
+            val = mda_out[key]
+            if isinstance(val, (list, tuple, set)):
+                typ = type(val)
+                new_vals = typ([aliases[key].get(itm, itm) for itm in val])
+                mda_out[key] = new_vals
+            else:
+                mda_out[key] = aliases[key].get(mda_out[key], mda_out[key])
     job['input_mda'] = mda_out.copy()
 
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -30,10 +30,10 @@ from six.moves.queue import Empty as queue_empty
 from multiprocessing import Process
 import yaml
 try:
-    from yaml import UnsafeLoader, SafeLoader
+    from yaml import UnsafeLoader, BaseLoader
 except ImportError:
     from yaml import Loader as UnsafeLoader
-    from yaml import SafeLoader
+    from yaml import BaseLoader
 import time
 from trollflow2 import gen_dict_extract, plist_iter, AbortProcessing
 from collections import OrderedDict
@@ -54,7 +54,7 @@ DEFAULT_PRIORITY = 999
 def run(prod_list, topics=None):
 
     with open(prod_list) as fid:
-        config = yaml.load(fid.read(), Loader=SafeLoader)
+        config = yaml.load(fid.read(), Loader=BaseLoader)
     topics = topics or config['common'].pop('subscribe_topics', None)
 
     listener = ListenerContainer(topics=topics)

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -538,6 +538,17 @@ class TestMetadataAlias(unittest.TestCase):
         self.assertTrue(mda['not_changed'])
         self.assertTrue('not_in_mda' not in mda)
 
+    def test_iterable_metadata(self):
+        from trollflow2 import metadata_alias
+        mda = {'sensor': ('a/b',), 'foo': set(['c/d'])}
+        product_list = {'common': {'metadata_aliases':
+                                   {'sensor': {'a/b': 'a-b'},
+                                    'foo': {'c/d': 'c\d'}}}}
+        job = {'input_mda': mda, 'product_list': product_list}
+        metadata_alias(job)
+        self.assertEqual(job['input_mda']['sensor'], ('a-b',))
+        self.assertEqual(job['input_mda']['foo'], set(['c\d']))
+
 
 class TestGetPluginConf(unittest.TestCase):
 


### PR DESCRIPTION
Some times input metadata has values in a list, tuple or set (e.g. "sensor"). These values were not aliased properly earlier, and this PR fixes those cases.