### PR TITLE
Add non-noisy publisher

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -146,7 +146,7 @@ workers:
   - fun: !!python/name:trollflow2.load_composites
   - fun: !!python/name:trollflow2.resample
   - fun: !!python/name:trollflow2.save_datasets
-  - fun: !!python/object:trollflow2.FilePublisher {}
+  - fun: !!python/object:trollflow2.NoisyFilePublisher {}
 
 # Things to run in case of a crash
 #crash_handlers:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -144,7 +144,7 @@ def save_datasets(job):
     compute_writer_results(objs)
 
 
-class FilePublisher(object):
+class NoisyFilePublisher(object):
     # todo add support for custom port and nameserver
     def __new__(cls):
         self = super().__new__(cls)

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -54,6 +54,8 @@ from collections import OrderedDict
 from trollsift import compose
 import dpath
 import os
+import time
+
 
 LOG = getLogger("trollflow2_plugins")
 
@@ -171,6 +173,8 @@ def file_publisher(job):
     mda.pop('collection', None)
     prod_list = job['product_list']
     with Publish("l2processor") as pub:
+        # Wait for a while so that publisher is registered properly
+        time.sleep(0.1)
         _send_messages(pub, prod_list, mda)
 
 

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -29,6 +29,7 @@ try:
     from satpy.resample import get_area_def
     from posttroll.message import Message
     from posttroll.publisher import NoisyPublisher
+    from posttroll.publisher import Publish
     from pyorbital.astronomy import sun_zenith_angle
     import rasterio
     from rasterio.enums import Resampling
@@ -38,6 +39,7 @@ except ImportError:
     get_area_def = None
     Message = None
     NoisyPublisher = None
+    Publish = None
     sun_zenith_angle = None
     rasterio = None
     Resampling = None
@@ -160,6 +162,16 @@ class NoisyFilePublisher(object):
         prod_list = job['product_list']
         _send_messages(self.pub, prod_list, mda)
         self.pub.stop()
+
+
+def file_publisher(job):
+    """Simple message publisher"""
+    mda = job['input_mda'].copy()
+    mda.pop('dataset', None)
+    mda.pop('collection', None)
+    prod_list = job['product_list']
+    with Publish("l2processor") as pub:
+        _send_messages(pub, prod_list, mda)
 
 
 def _send_messages(pub, prod_list, mda):

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -157,23 +157,26 @@ class FilePublisher(object):
         mda = job['input_mda'].copy()
         mda.pop('dataset', None)
         mda.pop('collection', None)
-        for fmat, fmat_config in plist_iter(job['product_list']['product_list']):
-            prod_path = "/product_list/%s/%s" % (fmat['area'], fmat['product'])
-            topic_pattern = get_config_value(job['product_list'],
-                                             prod_path,
-                                             "publish_topic")
-
-            file_mda = mda.copy()
-            try:
-                file_mda['uri'] = fmat['filename']
-            except KeyError:
-                continue
-            file_mda['uid'] = os.path.basename(fmat['filename'])
-            topic = compose(topic_pattern, fmat)
-            msg = Message(topic, 'file', file_mda)
-            LOG.debug('Publishing %s', str(msg))
-            self.pub.send(str(msg))
+        prod_list = job['product_list']
+        _send_messages(self.pub, prod_list, mda)
         self.pub.stop()
+
+
+def _send_messages(pub, prod_list, mda):
+    """Send messages using publisher *pub*"""
+    for fmat, _ in plist_iter(prod_list['product_list']):
+        prod_path = "/product_list/%s/%s" % (fmat['area'], fmat['product'])
+        topic_pattern = get_config_value(prod_list, prod_path, "publish_topic")
+        file_mda = mda.copy()
+        try:
+            file_mda['uri'] = fmat['filename']
+        except KeyError:
+            continue
+        file_mda['uid'] = os.path.basename(fmat['filename'])
+        topic = compose(topic_pattern, fmat)
+        msg = Message(topic, 'file', file_mda)
+        LOG.debug('Publishing %s', str(msg))
+        pub.send(str(msg))
 
 
 def covers(job):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -716,6 +716,21 @@ class TestNoisyFilePublisher(unittest.TestCase):
                     self.assertTrue(topics[i] in str(message.mock_calls[i]))
                     i += 1
 
+
+class TestFilePublisher(unittest.TestCase):
+
+    @mock.patch('trollflow2._send_messages')
+    @mock.patch('trollflow2.Publish')
+    def test_file_publisher(self, Publish, send_messages):
+        from trollflow2 import file_publisher
+        Publish.return_value.__enter__.return_value = 'pub'
+        mda = {'dataset': None, 'collection': None, 'bar': 'baz'}
+        prod_list = 'foo'
+        file_publisher({'input_mda': mda, 'product_list': prod_list})
+        # dataset and collection are removed from the metadata dict
+        send_messages.assert_called_with('pub', 'foo', {'bar': 'baz'})
+
+
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()
@@ -733,6 +748,7 @@ def suite():
     my_suite.addTest(loader.loadTestsFromTestCase(TestSZACheck))
     my_suite.addTest(loader.loadTestsFromTestCase(TestOverviews))
     my_suite.addTest(loader.loadTestsFromTestCase(TestNoisyFilePublisher))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestFilePublisher))
 
     return my_suite
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -635,7 +635,7 @@ class TestOverviews(unittest.TestCase):
                                                 resampling='average')
 
 
-class TestFilePublisher(unittest.TestCase):
+class TestNoisyFilePublisher(unittest.TestCase):
 
     def setUp(self):
         self.product_list = yaml.load(yaml_test2, Loader=UnsafeLoader)
@@ -647,10 +647,10 @@ class TestFilePublisher(unittest.TestCase):
     @mock.patch('trollflow2.Message')
     @mock.patch('trollflow2.NoisyPublisher')
     def test_filepublisher_with_compose(self, noisy_pub, message):
-        from trollflow2 import FilePublisher, plist_iter
+        from trollflow2 import NoisyFilePublisher, plist_iter
         from trollsift import compose
         import os.path
-        pub = FilePublisher()
+        pub = NoisyFilePublisher()
         pub.pub.start.assert_called_once()
         product_list = self.product_list.copy()
         product_list['common']['publish_topic'] = '/{areaname}/{productname}'
@@ -683,10 +683,10 @@ class TestFilePublisher(unittest.TestCase):
     @mock.patch('trollflow2.Message')
     @mock.patch('trollflow2.NoisyPublisher')
     def test_filepublisher_without_compose(self, noisy_pub, message):
-        from trollflow2 import FilePublisher, plist_iter
+        from trollflow2 import NoisyFilePublisher, plist_iter
         from trollsift import compose
         import os.path
-        pub = FilePublisher()
+        pub = NoisyFilePublisher()
         pub.pub.start.assert_called_once()
         product_list = self.product_list.copy()
         product_list['common']['publish_topic'] = '/static_topic'
@@ -732,7 +732,7 @@ def suite():
     my_suite.addTest(loader.loadTestsFromTestCase(TestGetPluginConf))
     my_suite.addTest(loader.loadTestsFromTestCase(TestSZACheck))
     my_suite.addTest(loader.loadTestsFromTestCase(TestOverviews))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestFilePublisher))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestNoisyFilePublisher))
 
     return my_suite
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -639,7 +639,7 @@ class TestFilePublisher(unittest.TestCase):
 
     def setUp(self):
         self.product_list = yaml.load(yaml_test2, Loader=UnsafeLoader)
-        # Skip omerc_bb are, there's no fname_pattern
+        # Skip omerc_bb area, there's no fname_pattern
         del self.product_list['product_list']['omerc_bb']
         self.input_mda = input_mda.copy()
         self.input_mda['uri'] = 'foo.nc'


### PR DESCRIPTION
This PR adds a publisher that doesn't broadcast its own name and address.

Also renames the `FilePublisher` as `NoisyFilePublisher`.