### PR TITLE
Use only one sensor for coverage calculations

### DIFF
--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -203,6 +203,10 @@ def covers(job):
     start_time = scn_mda['start_time']
     end_time = scn_mda['end_time']
     sensor = scn_mda['sensor']
+    if isinstance(sensor, (list, tuple, set)):
+        sensor = list(sensor)[0]
+        LOG.warning("Possibly many sensors given, taking only one for "
+                    "coverage calculations: %s", sensor)
 
     areas = list(product_list['product_list'].keys())
     for area in areas:

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -459,6 +459,19 @@ class TestCovers(unittest.TestCase):
         self.assertTrue("germ" in job['product_list']['product_list'])
         self.assertTrue("omerc_bb" in job['product_list']['product_list'])
 
+        # Test that only one sensor is used
+        input_mda = self.input_mda.copy()
+        input_mda['sensor'] = {'avhrr-4'}
+        job = {"product_list": self.product_list,
+               "input_mda": input_mda,
+               "scene": scn}
+        get_scene_coverage.reset_mock()
+        covers(job)
+        get_scene_coverage.assert_called_with(input_mda['platform_name'],
+                                              input_mda['start_time'],
+                                              input_mda['end_time'],
+                                              'avhrr-4', 'omerc_bb')
+
     @mock.patch('trollflow2.get_area_def')
     @mock.patch('trollflow2.Pass')
     def test_scene_coverage(self, ts_pass, get_area_def):


### PR DESCRIPTION
Trollstalker/gatherer/etc. may have multiple sensors defined in the metadata as a list, set or tuple. This PR takes only one of the sensors when estimating the area coverage.