### PR TITLE
Fix hanging publisher

### DIFF
--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -173,6 +173,9 @@ class FilePublisher(object):
             msg = Message(topic, 'file', file_mda)
             LOG.debug('Publishing %s', str(msg))
             self.pub.send(str(msg))
+
+    def __del__(self):
+        """Stop the publisher when last reference is deleted."""
         self.pub.stop()
 
 

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -173,6 +173,7 @@ class FilePublisher(object):
             msg = Message(topic, 'file', file_mda)
             LOG.debug('Publishing %s', str(msg))
             self.pub.send(str(msg))
+        self.pub.stop()
 
     def __del__(self):
         """Stop the publisher when last reference is deleted."""

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -145,13 +145,16 @@ def process(msg, prod_list):
                     cwrk = wrk.copy()
                     cwrk.pop('fun')(job, **cwrk)
             except AbortProcessing as err:
-                LOG.info(str(err))
+                LOG.info("Worker %s failed: %s", str(wrk['fun']), str(err))
     except Exception:
         LOG.exception("Process crashed")
         if "crash_handlers" in config:
             trace = traceback.format_exc()
             for hand in config['crash_handlers']['handlers']:
                 hand['fun'](config['crash_handlers']['config'], trace)
+
+    # Remove config so all remaining references are removed
+    del config
 
 
 def sendmail(config, trace):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -72,7 +72,6 @@ def run(prod_list, topics=None):
         proc = Process(target=process, args=(msg, prod_list))
         proc.start()
         proc.join()
-        time.sleep(5)
 
 
 def get_area_priorities(product_list):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -40,6 +40,7 @@ from collections import OrderedDict
 import copy
 from six.moves.urllib.parse import urlparse
 import traceback
+import gc
 
 """The order of basic things is:
 - Create the scene
@@ -156,8 +157,10 @@ def process(msg, prod_list):
             for hand in config['crash_handlers']['handlers']:
                 hand['fun'](config['crash_handlers']['config'], trace)
 
-    # Remove config so all remaining references are removed
+    # Remove config and run grabage collection so all remaining
+    # references e.g. to FilePublisher should be removed
     del config
+    gc.collect()
 
 
 def sendmail(config, trace):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -145,6 +145,10 @@ def process(msg, prod_list):
                     cwrk.pop('fun')(job, **cwrk)
             except AbortProcessing as err:
                 LOG.info("Worker %s failed: %s", str(wrk['fun']), str(err))
+    except (IOError, yaml.YAMLError):
+        # Either open() or yaml.load() failed
+        LOG.exception("Process crashed, check YAML file.")
+        return
     except Exception:
         LOG.exception("Process crashed")
         if "crash_handlers" in config:

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -144,7 +144,7 @@ def process(msg, prod_list):
                     cwrk = wrk.copy()
                     cwrk.pop('fun')(job, **cwrk)
             except AbortProcessing as err:
-                LOG.info("Worker %s failed: %s", str(wrk['fun']), str(err))
+                LOG.info(str(err))
     except (IOError, yaml.YAMLError):
         # Either open() or yaml.load() failed
         LOG.exception("Process crashed, check YAML file.")

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -188,10 +188,9 @@ class TestRun(unittest.TestCase):
     @mock.patch('trollflow2.launcher.yaml.load')
     @mock.patch('trollflow2.launcher.open')
     @mock.patch('trollflow2.launcher.process')
-    @mock.patch('trollflow2.launcher.time.sleep')
     @mock.patch('trollflow2.launcher.Process')
     @mock.patch('trollflow2.launcher.ListenerContainer')
-    def test_run(self, lc_, Process, sleep, process, _open, yaml_load):
+    def test_run(self, lc_, Process, process, _open, yaml_load):
         from trollflow2.launcher import run
         listener = mock.MagicMock()
         listener.output_queue.get.return_value = 'foo'
@@ -199,7 +198,7 @@ class TestRun(unittest.TestCase):
         proc_ret = mock.MagicMock()
         Process.return_value = proc_ret
         # stop looping
-        sleep.side_effect = KeyboardInterrupt
+        proc_ret.join.side_effect = KeyboardInterrupt
         yaml_load.return_value = self.config
         prod_list = 'bar'
         try:
@@ -210,7 +209,6 @@ class TestRun(unittest.TestCase):
         Process.assert_called_with(args=('foo', prod_list), target=process)
         proc_ret.start.assert_called_once()
         proc_ret.join.assert_called_once()
-        sleep.called_once_with(5)
         lc_.assert_called_with(topics=['/topic1', '/topic2'])
         # Subscriber topics are removed from config
         self.assertTrue('subscribe_topics' not in self.config['common'])

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -684,6 +684,7 @@ class TestFilePublisher(unittest.TestCase):
         pub(job)
         message.assert_called()
         pub.pub.send.assert_called()
+        pub.__del__()
         pub.pub.stop.assert_called()
         i = 0
         for area in job['product_list']['product_list']:
@@ -720,6 +721,7 @@ class TestFilePublisher(unittest.TestCase):
         pub(job)
         message.assert_called()
         pub.pub.send.assert_called()
+        pub.__del__()
         pub.pub.stop.assert_called()
         i = 0
         for area in job['product_list']['product_list']:


### PR DESCRIPTION
In the case when there were a crash or all the products were discarded the later plugins were not called. When `FilePublisher` was used, this caused the initialised publisher not to be closed, as the publisher was stopped in the `__call__()` method. With this PR the publisher will be closed when the instance is deleted and garbage collected.