### PR TITLE
Allow saving files to a temporary name and small fixes

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -95,7 +95,7 @@ def get_area_priorities(product_list):
 def message_to_jobs(msg, product_list):
     """Convert a posttroll message *msg* to a list of jobs given a *product_list*."""
     formats = product_list['product_list'].get('formats', None)
-    for product, pconfig in plist_iter(product_list['product_list'], level='product'):
+    for _product, pconfig in plist_iter(product_list['product_list'], level='product'):
         if 'formats' not in pconfig and formats is not None:
             pconfig['formats'] = formats.copy()
     jobs = OrderedDict()
@@ -110,7 +110,8 @@ def message_to_jobs(msg, product_list):
         for section in product_list:
             if section == 'product_list':
                 if section not in jobs[prio]['product_list']:
-                    jobs[prio]['product_list'][section] = OrderedDict()
+                    jobs[prio]['product_list'][section] = OrderedDict(product_list[section].copy())
+                    del jobs[prio]['product_list'][section]['areas']
                     jobs[prio]['product_list'][section]['areas'] = OrderedDict()
                 for area in areas:
                     jobs[prio]['product_list'][section]['areas'][area] = product_list[section]['areas'][area]

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -265,7 +265,7 @@ def check_platform(job):
     """Check if the platform is valid.  If not, discard the scene."""
     mda = job['input_mda']
     product_list = job['product_list']
-    conf = get_config_value(product_list, '/common', 'processed_platforms')
+    conf = get_config_value(product_list, '/product_list', 'processed_platforms')
     if conf is None:
         return
     platform = mda['platform_name']
@@ -278,7 +278,7 @@ def metadata_alias(job):
     """Replace input metadata values with aliases."""
     mda_out = job['input_mda'].copy()
     product_list = job['product_list']
-    aliases = get_config_value(product_list, '/common', 'metadata_aliases')
+    aliases = get_config_value(product_list, '/product_list', 'metadata_aliases')
     if aliases is None:
         return
     for key in aliases:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -125,7 +125,14 @@ def resample(job):
 
 
 def save_datasets(job):
-    """Save the datasets (and trigger the computation)."""
+    """Save the datasets (and trigger the computation).
+
+    If the `use_tmp_file` option is provided in the product list and is set to
+    True, the file will be first saved to a temporary name before being renamed.
+    This is useful when other processes are waiting for the file to be present
+    to start their work, but would crash on incomplete files.
+
+    """
     scns = job['resampled_scenes']
     objs = []
     base_config = job['input_mda'].copy()

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -376,14 +376,14 @@ def check_sunlight_coverage(job):
     areas = list(product_list['product_list'].keys())
 
     for area in areas:
-        products = list(product_list['product_list'][area]['products'].keys())
+        products = list(product_list['product_list']['areas'][area]['products'].keys())
         for product in products:
             try:
                 area_def = job['resampled_scenes'][area][product].attrs['area']
             except KeyError:
                 LOG.warning("No dataset %s for this scene and area %s", product, area)
                 continue
-            prod_path = "/product_list/%s/products/%s" % (area, product)
+            prod_path = "/product_list/areas/%s/products/%s" % (area, product)
             config = get_config_value(product_list, prod_path, "sunlight_coverage")
             if config is None:
                 continue

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -178,6 +178,8 @@ class TestMessageToJobs(TestCase):
                                                                   'writer': 'geotiff'}],
                                                      'productname': 'overview'}}})])
         self.assertDictEqual(jobs[999]['product_list']['product_list']['areas'], expected)
+        self.assertIn('output_dir', jobs[999]['product_list']['product_list'])
+
 
 class TestRun(TestCase):
 


### PR DESCRIPTION
Introduce the `use_tmp_file` parameter to allow saving the data to a temp file before renaming it to it's final name.

We also included fixes for the previous PR #40