### PR TITLE
Allow multiple bands tuple to be passed as a single composite

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -78,7 +78,7 @@ Example
               - format: png
                 writer: simple_image
                 fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
-          ("1", "2"):
+          ("1", "2"):  # This will load both channels one and two, but will keep them together when being saved to a single file.
             productname: visible_channels
             formats:
               - format: nc

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,13 +35,79 @@ The `check_sunlight_coverage` plugin
 .. function:: check_sunlight_coverage
 
 
-              
+
 Product list
 ------------
 
 * `resolution` is available only at the root and product levels
 * `productname`, `areaname` are the names to use for product and area in the
-  filename. If not provided, they default to the actual product and area names. 
+  filename. If not provided, they default to the actual product and area names.
+
+Example
+*******
+
+.. code-block:: yaml
+
+  product_list:
+    output_dir: &output_dir
+      "/data/{variant}/"
+    use_extern_calib: false
+    fname_pattern: &fname
+      "{platform_name}_{start_time:%Y%m%d_%H%M}_{areaname}_{productname}.{format}"
+    publish_topic: /raster/2A/avhrr
+    reader: avhrr_l1b_aapp
+    mask_area: True
+    delay_composites: True
+    use_tmp_file: True
+    metadata_aliases:
+      variant:
+        EARS: regional
+        DR: direct_readout
+    min_coverage: 25
+    areas:
+      baws:
+        areaname: baws
+        products:
+          overview_sun:
+            sunlight_coverage:
+              min: 10
+              check_pass: True
+            productname: overview
+            output_dir: "/data/some/other/place"
+            formats:
+              - format: png
+                writer: simple_image
+                fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
+          ("1", "2"):
+            productname: visible_channels
+            formats:
+              - format: nc
+                writer: cf
+                fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
+          green_snow:
+            sunlight_coverage:
+              min: 10
+              check_pass: True
+            productname: green_snow
+            formats:
+              - format: tif
+                writer: geotiff
+                fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
+          natural_color_sun:
+            sunlight_coverage:
+              min: 10
+              check_pass: True
+            productname: natural_color
+            formats:
+              - format: tif
+                writer: geotiff
+                fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_natural_{variant:s}.{format}"
+          cloudtop:
+            productname: cloudtop
+            formats:
+              - format: tif
+                writer: geotiff
+                fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
 
 
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -20,43 +20,58 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
+"""Launcher for trollflow2."""
 
+import ast
+import copy
+import gc
+import re
+import traceback
+from collections import OrderedDict
 from logging import getLogger
+
+import yaml
+from six.moves.queue import Empty
+from six.moves.urllib.parse import urlparse
+
+from trollflow2.dict_tools import gen_dict_extract, plist_iter
+from trollflow2.plugins import AbortProcessing
+
 try:
     from posttroll.listener import ListenerContainer
 except ImportError:
     ListenerContainer = None
-from six.moves.queue import Empty as queue_empty
 
-import yaml
 try:
     from yaml import UnsafeLoader, BaseLoader
 except ImportError:
     from yaml import Loader as UnsafeLoader
     from yaml import BaseLoader
 
-from trollflow2.dict_tools import gen_dict_extract, plist_iter
-from trollflow2.plugins import AbortProcessing
-from collections import OrderedDict
-import copy
-from six.moves.urllib.parse import urlparse
-import traceback
-import gc
-
-"""The order of basic things is:
-- Create the scene
-- Generate the composites
-- Resample
-- Save to file
-"""
 
 LOG = getLogger("launcher")
 DEFAULT_PRIORITY = 999
 
 
-def get_test_message(test_message_file):
-    """Read file and retrieve the test message"""
+def tuple_constructor(loader, node):
+    """Construct a tuple."""
+    def parse_tup_el(el):
+        return ast.literal_eval(el.strip())
+    value = loader.construct_scalar(node)
+    tup_elements = value[1:-1].split(',')
+    if tup_elements[-1] == '':
+        tup_elements.pop(-1)
+    tup = tuple((parse_tup_el(el) for el in tup_elements))
+    return tup
 
+
+tuple_regex = r'\( *([\w.]+|"[\w\s.]*") *(, *([\w.]+|"[\w\s.]*") *)*((, *([\w.]+|"[\w\s.]*") *)|(, *))\)'
+yaml.add_constructor(u'!tuple', tuple_constructor, UnsafeLoader)
+yaml.add_implicit_resolver(u'!tuple', re.compile(tuple_regex), None, UnsafeLoader)
+
+
+def get_test_message(test_message_file):
+    """Read file and retrieve the test message."""
     msg = None
     if test_message_file:
         with open(test_message_file) as fpt:
@@ -66,7 +81,7 @@ def get_test_message(test_message_file):
 
 
 def run(prod_list, topics=None, test_message=None):
-
+    """Run."""
     tmessage = get_test_message(test_message)
     if tmessage:
         from threading import Thread as Process
@@ -91,7 +106,7 @@ def run(prod_list, topics=None, test_message=None):
             if not tmessage:
                 listener.stop()
             return
-        except queue_empty:
+        except Empty:
             continue
 
         proc = Process(target=process, args=(msg, prod_list))

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -27,8 +27,6 @@ import os
 import unittest
 from unittest import mock
 
-from trollflow2.launcher import yaml, UnsafeLoader
-
 from trollflow2.tests.utils import TestCase
 
 
@@ -320,6 +318,7 @@ class TestSaveDatasets(TestCase):
     def test_save_datasets(self):
         """Test saving datasets."""
         self.maxDiff = None
+        from trollflow2.launcher import yaml, UnsafeLoader
         from trollflow2.plugins import save_datasets
         job = {}
         job['input_mda'] = input_mda
@@ -516,6 +515,7 @@ class TestLoadComposites(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml, UnsafeLoader
         self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
     def test_load_composites(self):
@@ -555,6 +555,7 @@ class TestResample(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml, UnsafeLoader
         self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
     def test_resample(self):
@@ -679,6 +680,7 @@ class TestSunlightCovers(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml, UnsafeLoader
         self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
@@ -706,6 +708,7 @@ class TestCheckSunlightCoverage(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml, UnsafeLoader
         self.product_list = yaml.load(yaml_test3, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
@@ -746,6 +749,7 @@ class TestCovers(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml, UnsafeLoader
         self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
@@ -921,6 +925,7 @@ class TestSZACheck(TestCase):
             scene = mock.MagicMock()
             scene.attrs = {'start_time': 42}
             job['scene'] = scene
+            from trollflow2.launcher import yaml, UnsafeLoader
             product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
             job['product_list'] = product_list.copy()
             # Run without any settings
@@ -962,6 +967,7 @@ class TestOverviews(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml
         self.product_list = yaml.load(yaml_test1)
 
     def test_add_overviews(self):
@@ -990,6 +996,7 @@ class TestFilePublisher(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
+        from trollflow2.launcher import yaml, UnsafeLoader
         self.product_list = yaml.load(yaml_test_publish, Loader=UnsafeLoader)
         # Skip omerc_bb area, there's no fname_pattern
         del self.product_list['product_list']['areas']['omerc_bb']

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -22,38 +22,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 """Test plugins."""
 
-import ast
 import datetime as dt
 import os
-import re
 import unittest
 from unittest import mock
 
-import yaml
+from trollflow2.launcher import yaml, UnsafeLoader
 
 from trollflow2.tests.utils import TestCase
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader
-
-
-def tuple_constructor(loader, node):
-    """Construct a tuple."""
-    def parse_tup_el(el):
-        return ast.literal_eval(el.strip())
-    value = loader.construct_scalar(node)
-    tup_elements = value[1:-1].split(',')
-    if tup_elements[-1] == '':
-        tup_elements.pop(-1)
-    tup = tuple((parse_tup_el(el) for el in tup_elements))
-    return tup
-
-
-tuple_regex = r'\( *([\w.]+|"[\w\s.]*") *(, *([\w.]+|"[\w\s.]*") *)*((, *([\w.]+|"[\w\s.]*") *)|(, *))\)'
-yaml.add_constructor(u'!tuple', tuple_constructor, UnsafeLoader)
-yaml.add_implicit_resolver(u'!tuple', re.compile(tuple_regex), None, UnsafeLoader)
 
 
 yaml_test1 = """


### PR DESCRIPTION
The following syntax is now accepted in the YAML config file:

```yaml
    areas:
      baws:
        areaname: baws
        products:
          overview_sun:
          # ...
          ("1", "2"):
            productname: visible_channels
            formats:
              - format: nc
                writer: cf
                fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
```