### PR TITLE
Add the possibility to add extra metadata to the published messages

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -35,6 +35,9 @@ product_list: &product_list
   # Check area coverage by `collection_area_id` in the input metadata.
   #   Default: False
   # coverage_by_collection_area: True
+  # Add extra metadata to the published messages
+  # extra_metadata:
+  #   processing_center: SMHI
 
   areas:
     omerc_bb:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -253,6 +253,7 @@ class FilePublisher(object):
         """Create a message topic and mda."""
         topic_pattern = fmat["publish_topic"]
         file_mda = mda.copy()
+        file_mda.update(fmat.get('extra_metadata', {}))
 
         file_mda['uri'] = os.path.abspath(fmat['filename'])
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -82,6 +82,8 @@ product_list:
   something: foo
   min_coverage: 5.0
   publish_topic: /raster/
+  extra_metadata:
+    processing_center: SMHI
   areas:
       euron1:
         areaname: euron1_in_fname
@@ -1040,6 +1042,7 @@ class TestFilePublisher(TestCase):
                     if 'call().__str__()' != str(message.mock_calls[i]):
                         self.assertTrue(topics[i] in str(message.mock_calls[i]))
                         i += 1
+            self.assertEqual(message.call_args[0][2]['processing_center'], 'SMHI')
 
     def test_filepublisher_without_compose(self):
         """Test filepublisher without compose."""
@@ -1103,27 +1106,6 @@ class TestFilePublisher(TestCase):
                                      'ftp://ftp.important_client.com/somewhere/NOAA-15_20190217_0600_euron1_in_fname_ctth_static.png')  # noqa
                     dispatches += 1
             self.assertEqual(dispatches, 1)
-
-
-def suite():
-    """Test suite for test_writers."""
-    loader = unittest.TestLoader()
-    my_suite = unittest.TestSuite()
-    my_suite.addTest(loader.loadTestsFromTestCase(TestSaveDatasets))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestCreateScene))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestLoadComposites))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestResample))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestCovers))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestCheckPlatform))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestMetadataAlias))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestGetPluginConf))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestSZACheck))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestSunlightCovers))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestCheckSunlightCoverage))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestOverviews))
-    my_suite.addTest(loader.loadTestsFromTestCase(TestFilePublisher))
-
-    return my_suite
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR allows the addition of arbitrary metadata to the published messages with the `extra_metadata` configuration parameter.