### PR TITLE
Add "nameserver" and "addresses" command-line options

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -46,10 +46,11 @@ def parse_args():
                         help="Log config file (yaml) to use",
                         type=str, required=False)
     parser.add_argument('-n', "--nameserver", required=False, type=str,
-                        help="Nameserver to connect to")
+                        help="Nameserver to connect to", default='localhost')
     parser.add_argument('-a', "--addresses", required=False, type=str,
-                        help=("Direct TCP portconnections as comma-separated "
-                              "list: 'tcp://127.0.0.1:12345,tcp://123.456.789.0:9013'"))
+                        help=("Add direct TCP port connection.  Can be used several times: "
+                              "'-a tcp://127.0.0.1:12345 -a tcp://123.456.789.0:9013'"),
+                        action="append")
 
     return parser.parse_args()
 
@@ -60,10 +61,8 @@ def main():
     prod_list = args.product_list
     test_message = args.test_message
     topics = args.topic
-    nameserver = args.nameserver or "localhost"
+    nameserver = args.nameserver
     addresses = args.addresses
-    if isinstance(addresses, str):
-        addresses = addresses.split(',')
 
     if args.log_config is not None:
         with open(args.log_config) as fd:

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -28,8 +28,9 @@ import argparse
 from trollflow2.launcher import run
 import logging
 
-if __name__ == "__main__":
 
+def parse_args():
+    """Parse commandline arguments."""
     parser = argparse.ArgumentParser(
         description='Launch trollflow2 processing with Satpy listening on the specified Posttroll topic(s)')
     parser.add_argument("topic", nargs='*',
@@ -44,11 +45,25 @@ if __name__ == "__main__":
     parser.add_argument("--log-config", '-c',
                         help="Log config file (yaml) to use",
                         type=str, required=False)
+    parser.add_argument('-n', "--nameserver", required=False, type=str,
+                        help="Nameserver to connect to")
+    parser.add_argument('-a', "--addresses", required=False, type=str,
+                        help=("Direct TCP portconnections as comma-separated "
+                              "list: 'tcp://127.0.0.1:12345,tcp://123.456.789.0:9013'"))
 
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    """Launch trollflow2."""
+    args = parse_args()
     prod_list = args.product_list
     test_message = args.test_message
     topics = args.topic
+    nameserver = args.nameserver or "localhost"
+    addresses = args.addresses
+    if isinstance(addresses, str):
+        addresses = addresses.split(',')
 
     if args.log_config is not None:
         with open(args.log_config) as fd:
@@ -61,4 +76,9 @@ if __name__ == "__main__":
 
     LOG = getLogger("satpy_launcher")
 
-    run(prod_list, topics=topics, test_message=test_message)
+    run(prod_list, topics=topics, test_message=test_message,
+        nameserver=nameserver, addresses=addresses)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -150,8 +150,8 @@ workers:
   - fun: !!python/name:trollflow2.plugins.resample
   - fun: !!python/name:trollflow2.plugins.save_datasets
   - fun: !!python/object:trollflow2.plugins.FilePublisher {}
-  # Or add "nameservers" kwarg
-  # - fun: !!python/object:trollflow2.plugins.FilePublisher {nameservers: [localhost]}
+  # Or add keyword arguments
+  # - fun: !!python/object:trollflow2.plugins.FilePublisher {port: 40002, nameservers: [localhost]}
 
 
 # Things to run in case of a crash

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -150,6 +150,9 @@ workers:
   - fun: !!python/name:trollflow2.plugins.resample
   - fun: !!python/name:trollflow2.plugins.save_datasets
   - fun: !!python/object:trollflow2.plugins.FilePublisher {}
+  # Or add "nameservers" kwarg
+  # - fun: !!python/object:trollflow2.plugins.FilePublisher {nameservers: [localhost]}
+
 
 # Things to run in case of a crash
 #crash_handlers:

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -183,6 +183,7 @@ def expand(yml):
 
 def process(msg, prod_list):
     """Process a message."""
+    config = {}
     try:
         with open(prod_list) as fid:
             config = yaml.load(fid.read(), Loader=UnsafeLoader)

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -85,7 +85,8 @@ def get_test_message(test_message_file):
     return msg
 
 
-def run(prod_list, topics=None, test_message=None):
+def run(prod_list, topics=None, test_message=None, nameserver='localhost',
+        addresses=None):
     """Spawn one or multiple subprocesses to run the jobs from the product list."""
     tmessage = get_test_message(test_message)
     if tmessage:
@@ -99,7 +100,8 @@ def run(prod_list, topics=None, test_message=None):
     topics = topics or config['product_list'].pop('subscribe_topics', None)
 
     if not tmessage:
-        listener = ListenerContainer(topics=topics)
+        listener = ListenerContainer(topics=topics, nameserver=nameserver,
+                                     addresses=addresses)
 
     while True:
         try:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -339,8 +339,9 @@ def covers(job):
         if job['input_mda']['collection_area_id'] not in job['product_list']['product_list']['areas']:
             raise AbortProcessing(
                 "Area collection ID '%s' does not match "
-                "production area(s) %s" % (job['input_mda']['collection_area_id'],
-                                           str(list(job['product_list']['product_list']))))
+                "production area(s) %s" % (
+                    job['input_mda']['collection_area_id'],
+                    str(list(job['product_list']['product_list']['areas']))))
 
     product_list = job['product_list'].copy()
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -240,11 +240,11 @@ class FilePublisher(object):
     """Publisher for generated files."""
 
     # todo add support for custom port and nameserver
-    def __new__(cls):
+    def __new__(cls, nameservers=None):
         """Create new instance."""
         self = super().__new__(cls)
         LOG.debug('Starting publisher')
-        self.pub = NoisyPublisher('l2processor')
+        self.pub = NoisyPublisher('l2processor', nameservers=nameservers)
         self.pub.start()
         return self
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -125,6 +125,7 @@ def resample(job):
             else:
                 job['resampled_scenes'][area] = scn
         else:
+            LOG.debug("area: %s, area_conf: %s", area, str(area_conf))
             job['resampled_scenes'][area] = scn.resample(area, **area_conf)
 
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -240,11 +240,12 @@ class FilePublisher(object):
     """Publisher for generated files."""
 
     # todo add support for custom port and nameserver
-    def __new__(cls, nameservers=None):
+    def __new__(cls, port=0, nameservers=None):
         """Create new instance."""
         self = super().__new__(cls)
         LOG.debug('Starting publisher')
-        self.pub = NoisyPublisher('l2processor', nameservers=nameservers)
+        self.pub = NoisyPublisher('l2processor', port=port,
+                                  nameservers=nameservers)
         self.pub.start()
         return self
 

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -220,7 +220,8 @@ class TestRun(TestCase):
             Process.assert_called_with(args=('foo', prod_list), target=process)
             proc_ret.start.assert_called_once()
             proc_ret.join.assert_called_once()
-            lc_.assert_called_with(topics=['/topic1', '/topic2'])
+            lc_.assert_called_with(addresses=None, nameserver='localhost',
+                                   topics=['/topic1', '/topic2'])
             # Subscriber topics are removed from config
             self.assertTrue('subscribe_topics' not in self.config['product_list'])
             # Topics are given as command line option
@@ -229,7 +230,8 @@ class TestRun(TestCase):
                 run(prod_list, topics=['/topic3'])
             except KeyboardInterrupt:
                 pass
-            lc_.assert_called_with(topics=['/topic3'])
+            lc_.assert_called_with(addresses=None, nameserver='localhost',
+                                   topics=['/topic3'])
 
     def test_run_keyboard_interrupt(self):
         """Test interrupting the run with a ctrl-C."""

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1085,9 +1085,9 @@ class TestFilePublisher(TestCase):
         with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb_:
             pub = FilePublisher()
             pub.pub.start.assert_called_once()
-            assert mock.call('l2processor', nameservers=None) in nb_.mock_calls
-            pub = FilePublisher(nameservers=['localhost'])
-            assert mock.call('l2processor',
+            assert mock.call('l2processor', port=0, nameservers=None) in nb_.mock_calls
+            pub = FilePublisher(port=40000, nameservers=['localhost'])
+            assert mock.call('l2processor', port=40000,
                              nameservers=['localhost']) in nb_.mock_calls
 
     def test_dispatch(self):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1079,6 +1079,17 @@ class TestFilePublisher(TestCase):
                         self.assertTrue(topics[i] in str(message.mock_calls[i]))
                         i += 1
 
+    def test_filepublisher_kwargs(self):
+        """Test filepublisher keyword argument usage."""
+        from trollflow2.plugins import FilePublisher
+        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher') as nb_:
+            pub = FilePublisher()
+            pub.pub.start.assert_called_once()
+            assert mock.call('l2processor', nameservers=None) in nb_.mock_calls
+            pub = FilePublisher(nameservers=['localhost'])
+            assert mock.call('l2processor',
+                             nameservers=['localhost']) in nb_.mock_calls
+
     def test_dispatch(self):
         """Test dispatch order messages."""
         from trollflow2.plugins import FilePublisher

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1082,7 +1082,7 @@ class TestFilePublisher(TestCase):
     def test_filepublisher_kwargs(self):
         """Test filepublisher keyword argument usage."""
         from trollflow2.plugins import FilePublisher
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher') as nb_:
+        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb_:
             pub = FilePublisher()
             pub.pub.start.assert_called_once()
             assert mock.call('l2processor', nameservers=None) in nb_.mock_calls


### PR DESCRIPTION
This PR adds two command-line options so that `nameserver` and `addresses` can be passed to `ListenerContainer`. With these options it should be possible to run `trollflow2` without multicast.

This also adds `nameservers` kwarg to `FilePublisher` class.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Tests updated
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
