### PR TITLE
Check the area from correct level of the product list

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -328,7 +328,7 @@ def covers(job):
 
     col_area = job['product_list']['product_list'].get('coverage_by_collection_area', False)
     if col_area and 'collection_area_id' in job['input_mda']:
-        if job['input_mda']['collection_area_id'] not in job['product_list']['product_list']:
+        if job['input_mda']['collection_area_id'] not in job['product_list']['product_list']['areas']:
             raise AbortProcessing(
                 "Area collection ID '%s' does not match "
                 "production area(s) %s" % (job['input_mda']['collection_area_id'],

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -834,11 +834,15 @@ class TestCovers(TestCase):
             # By default collection_area_id isn't checked so nothing should happen
             job['input_mda']['collection_area_id'] = 'not_in_pl'
             covers(job)
-            # Turn coverage check on, so area not in the product list should raise
-            # AbortProcessing
+            # Turn coverage check on, so area not in the product list
+            # should raise AbortProcessing
             job['product_list']['product_list']['coverage_by_collection_area'] = True
             with self.assertRaises(AbortProcessing):
                 covers(job)
+
+            # And with existing area there shouldn't be an exception
+            job['input_mda']['collection_area_id'] = 'euron1'
+            covers(job)
 
 
 class TestCheckPlatform(TestCase):


### PR DESCRIPTION
This PR fixes the usage of `coverage_by_collection_area` option. The current version wasn't updated when `areas` level was added to the product list.
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
