### PR TITLE
Ensure composites are generated for scenes without resampling

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -86,6 +86,12 @@ product_list: &product_list
               # overviews: [4, 8, 16, 32, 64, 128, 256]
     # null:  # satellite projection
     #   areaname: satellite_projection
+    #   # Use lowest listed priority for area in satellite projection.
+    #   #   To be able to save the data the composites need to be
+    #   #   created, and it will slow down processing for other areas.
+    #   #   The composites will be reloaded and created automatically
+    #   #   for this area.
+    #   priority: 3
     #   products:
     #     cloudtype:
     #       productname: cloudtype
@@ -138,6 +144,7 @@ product_list: &product_list
     #
     # germ:
     #   areaname: germ
+    #   priority: 2
     #   products:
     #     cloudtype:
     #       productname: cloudtype

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -123,6 +123,10 @@ def resample(job):
                 job['resampled_scenes'][area] = scn.resample(scn.max_area(),
                                                              **area_conf)
             else:
+                # The composites need to be created for the saving to work
+                if not set(scn.wishlist).issuperset(scn.wishlist):
+                    LOG.debug("Generating composites for 'null' area.")
+                    scn.load(scn.wishlist, generate=True)
                 job['resampled_scenes'][area] = scn
         else:
             LOG.debug("area: %s, area_conf: %s", area, str(area_conf))

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -125,7 +125,7 @@ def resample(job):
             else:
                 # The composites need to be created for the saving to work
                 if not set(scn.datasets.keys()).issuperset(scn.wishlist):
-                    LOG.debug("Generating composites for 'null' area.")
+                    LOG.debug("Generating composites for 'null' area (satellite projection).")
                     scn.load(scn.wishlist, generate=True)
                 job['resampled_scenes'][area] = scn
         else:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -124,7 +124,7 @@ def resample(job):
                                                              **area_conf)
             else:
                 # The composites need to be created for the saving to work
-                if not set(scn.wishlist).issuperset(scn.wishlist):
+                if not set(scn.datasets.keys()).issuperset(scn.wishlist):
                     LOG.debug("Generating composites for 'null' area.")
                     scn.load(scn.wishlist, generate=True)
                 job['resampled_scenes'][area] = scn

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -709,10 +709,16 @@ class TestResampleNullArea(TestCase):
         """Test handling a `None` area in resampling."""
         from trollflow2.plugins import resample
         scn = mock.MagicMock()
-        scn.datasets.keys.return_value = ['a', 'b', 'c']
-        scn.wishlist = {'abc'}
         product_list = self.product_list.copy()
         job = {"scene": scn, "product_list": product_list.copy()}
+        # The composites have been generated
+        scn.datasets.keys.return_value = ['abc']
+        scn.wishlist = {'abc'}
+        resample(job)
+        scn.load.assert_not_called()
+        # The composites have not been generated
+        scn.datasets.keys.return_value = ['a', 'b', 'c']
+        scn.wishlist = {'abc'}
         resample(job)
         self.assertTrue(mock.call({'abc'}, generate=True) in
                         scn.load.mock_calls)


### PR DESCRIPTION
This PR ensures that composites are generated also for `null` areas, i.e. for areas which are saved as-is without resampling.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
