### PR TITLE
Fix publisher stopping after first processed area

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -309,27 +309,24 @@ class FilePublisher(object):
 
     def __call__(self, job):
         """Call the publisher."""
-        try:
-            mda = job['input_mda'].copy()
-            mda.pop('dataset', None)
-            mda.pop('collection', None)
-            for fmat, fmat_config in plist_iter(job['product_list']['product_list'], mda):
-                try:
-                    topic, file_mda = self.create_message(fmat, mda)
-                except KeyError:
-                    LOG.debug('Could not create a message for %s.', str(fmat))
-                    continue
-                msg = Message(topic, 'file', file_mda)
-                LOG.debug('Publishing %s', str(msg))
-                self.pub.send(str(msg))
-                self.send_dispatch_messages(fmat, fmat_config, topic, file_mda)
-        finally:
-            if self.pub:
-                self.pub.stop()
+        mda = job['input_mda'].copy()
+        mda.pop('dataset', None)
+        mda.pop('collection', None)
+        for fmat, fmat_config in plist_iter(job['product_list']['product_list'], mda):
+            try:
+                topic, file_mda = self.create_message(fmat, mda)
+            except KeyError:
+                LOG.debug('Could not create a message for %s.', str(fmat))
+                continue
+            msg = Message(topic, 'file', file_mda)
+            LOG.debug('Publishing %s', str(msg))
+            self.pub.send(str(msg))
+            self.send_dispatch_messages(fmat, fmat_config, topic, file_mda)
 
     def __del__(self):
         """Stop the publisher when last reference is deleted."""
-        self.pub.stop()
+        if self.pub:
+            self.pub.stop()
 
 
 def covers(job):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1239,6 +1239,21 @@ class TestFilePublisher(TestCase):
                     dispatches += 1
             self.assertEqual(dispatches, 1)
 
+    def test_stopping(self):
+        """Test dispatch order messages."""
+        from trollflow2.plugins import FilePublisher
+        nb_ = mock.MagicMock()
+        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
+            nb.return_value = nb_
+            pub = FilePublisher()
+            job = {'product_list': self.product_list,
+                   'input_mda': self.input_mda}
+            pub(job)
+
+        nb_.stop.assert_not_called()
+        del pub
+        nb_.stop.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1243,7 +1243,7 @@ class TestFilePublisher(TestCase):
         """Test dispatch order messages."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
+        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
             nb.return_value = nb_
             pub = FilePublisher()
             job = {'product_list': self.product_list,


### PR DESCRIPTION
This PR fixes the publisher, which was stopped after the first processed areas. This caused the next area to have `None` as the publisher and a crash.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
