### PR TITLE
Stop the workers when the process is done

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -24,10 +24,26 @@ The launcher
     :show-inheritance:
 
 
-Available plugins
------------------
+Plugins
+-------
 
-.. currentmodule:: trollflow2.plugings
+The plugins are callables that are to be run in order for the batch processing
+to happen. These are usually functions, but they can be a class with a
+`__call__` method implemented. If they are to be instanciated from the yaml
+configuration file, a `__setstate__` method will need to be implemented if
+arguments are to be passed for the initialization of the class.
+
+If the callable has a `stop` method, it will be called without arguments at the
+end of each run (one scene).
+
+An example of such a callable class used in trollflow2 is the
+`class:FilePublisher`.
+
+
+Available plugins
++++++++++++++++++
+
+.. currentmodule:: trollflow2.plugins
 
 The `check_sunlight_coverage` plugin
 ************************************

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -252,6 +252,11 @@ def process(msg, prod_list, produced_files):
         # Remove config and run garbage collection so all remaining
         # references e.g. to FilePublisher should be removed
         LOG.debug('Cleaning up')
+        for wrk in config.get("workers", []):
+            try:
+                wrk['fun'].stop()
+            except AttributeError:
+                continue
         del config
         gc.collect()
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -323,10 +323,14 @@ class FilePublisher(object):
             self.pub.send(str(msg))
             self.send_dispatch_messages(fmat, fmat_config, topic, file_mda)
 
-    def __del__(self):
-        """Stop the publisher when last reference is deleted."""
+    def stop(self):
+        """Stop the publisher."""
         if self.pub:
             self.pub.stop()
+
+    def __del__(self):
+        """Stop the publisher when last reference is deleted."""
+        self.stop()
 
 
 def covers(job):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -288,7 +288,9 @@ class TestProcess(TestCase):
 
             message_to_jobs.return_value = {1: {"job1": dict([])}}
             the_queue = mock.MagicMock()
+            fun1.stop.assert_not_called()
             process("msg", "prod_list", the_queue)
+            fun1.stop.assert_called_once()
             open_.assert_called_with("prod_list")
             yaml_.load.assert_called_once()
             message_to_jobs.assert_called_with("msg", {"workers": [{"fun": fun1}]})

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -291,10 +291,15 @@ class TestProcess(TestCase):
             fun1.stop.assert_not_called()
             process("msg", "prod_list", the_queue)
             fun1.stop.assert_called_once()
+
             open_.assert_called_with("prod_list")
             yaml_.load.assert_called_once()
             message_to_jobs.assert_called_with("msg", {"workers": [{"fun": fun1}]})
             fun1.assert_called_with({'job1': {}, 'processing_priority': 1, 'produced_files': the_queue})
+
+            fun1.stop = mock.MagicMock(side_effect=AttributeError('boo'))
+            process("msg", "prod_list", the_queue)
+
             # Test that errors are propagated
             fun1.side_effect = KeyboardInterrupt
             with self.assertRaises(KeyboardInterrupt):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1239,8 +1239,8 @@ class TestFilePublisher(TestCase):
                     dispatches += 1
             self.assertEqual(dispatches, 1)
 
-    def test_stopping(self):
-        """Test dispatch order messages."""
+    def test_deleting(self):
+        """Test deleting the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
         with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
@@ -1252,6 +1252,21 @@ class TestFilePublisher(TestCase):
 
         nb_.stop.assert_not_called()
         del pub
+        nb_.stop.assert_called_once()
+
+    def test_stopping(self):
+        """Test stopping the publisher."""
+        from trollflow2.plugins import FilePublisher
+        nb_ = mock.MagicMock()
+        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
+            nb.return_value = nb_
+            pub = FilePublisher()
+            job = {'product_list': self.product_list,
+                   'input_mda': self.input_mda}
+            pub(job)
+
+        nb_.stop.assert_not_called()
+        pub.stop()
         nb_.stop.assert_called_once()
 
 


### PR DESCRIPTION

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

