### PR TITLE
Fix formats dictionary being the same object

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -181,7 +181,7 @@ def message_to_jobs(msg, product_list):
     formats = product_list['product_list'].get('formats', None)
     for _product, pconfig in plist_iter(product_list['product_list'], level='product'):
         if 'formats' not in pconfig and formats is not None:
-            pconfig['formats'] = formats.copy()
+            pconfig['formats'] = copy.deepcopy(formats)
     jobs = OrderedDict()
     priorities = get_area_priorities(product_list)
     # TODO: check the uri is accessible from the current host.

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -189,6 +189,8 @@ class TestMessageToJobs(TestCase):
         prods = jobs[999]['product_list']['product_list']['areas']['euro4']['products']
         self.assertFalse(prods['overview']['formats'][0] is
                          prods['natural_color']['formats'][0])
+        prods['overview']['formats'][0]['foo'] = 'bar'
+        self.assertFalse('foo' in prods['natural_color']['formats'][0])
 
 
 class TestRun(TestCase):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -185,6 +185,10 @@ class TestMessageToJobs(TestCase):
                                                      'productname': 'overview'}}})])
         self.assertDictEqual(jobs[999]['product_list']['product_list']['areas'], expected)
         self.assertIn('output_dir', jobs[999]['product_list']['product_list'])
+        # Test that the formats are not the same object
+        prods = jobs[999]['product_list']['product_list']['areas']['euro4']['products']
+        self.assertFalse(prods['overview']['formats'][0] is
+                         prods['natural_color']['formats'][0])
 
 
 class TestRun(TestCase):


### PR DESCRIPTION
This PR fixes the `formats` dictionaries being the same object. This caused all the filenames being the same when a minimal product list without explicitly written `formats` section were used, see below.

```yaml
  formats:
    - format: tif
      writer: geotiff
  areas:
      euro4:
        areaname: euro4
        products:
          overview:
            productname: overview
          airmass:
            productname: airmass
```

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
