### PR TITLE
Use area definition names to check sunlight coverage

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -165,6 +165,10 @@ product_list: &product_list
 workers:
   - fun: !!python/name:trollflow2.plugins.create_scene
   # Check sunlight area coverage fraction.  See configuration above.
+  #   The worker can be in three different stages:
+  #   - after create_scene: when area is defined in areas.yaml
+  #   - after load_composites: when area is `null` (save full disk GEO data)
+  #   - after resampler: for backwards compatibility
   # - fun: !!python/name:trollflow2.plugins.check_sunlight_coverage
   - fun: !!python/name:trollflow2.plugins.load_composites
   - fun: !!python/name:trollflow2.plugins.resample

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -38,6 +38,14 @@ product_list: &product_list
   # Add extra metadata to the published messages
   # extra_metadata:
   #   processing_center: SMHI
+  # Check fraction of sunlit area.  Remove affected products outside the
+  #   given limits.  For daytime products define only `min`, and for nighttime
+  #   products define only `max`.  To check sunlit fraction within a swath of
+  #   a polar-orbiting satellite, define `check_pass: True`.
+  # sunlight_coverage:
+  #   min: 20.0  # if lower than this, products are removed
+  #   max: 80.0  # if higher than this, products are removed
+  #   check_pass: True  # check coverage within the swath
 
   areas:
     omerc_bb:
@@ -156,6 +164,8 @@ product_list: &product_list
 
 workers:
   - fun: !!python/name:trollflow2.plugins.create_scene
+  # Check sunlight area coverage fraction.  See configuration above.
+  # - fun: !!python/name:trollflow2.plugins.check_sunlight_coverage
   - fun: !!python/name:trollflow2.plugins.load_composites
   - fun: !!python/name:trollflow2.plugins.resample
   - fun: !!python/name:trollflow2.plugins.save_datasets

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -219,11 +219,12 @@ def expand(yml):
 
 def process(msg, prod_list, produced_files):
     """Process a message."""
+    from zmq.error import ZMQError
     config = {}
     try:
         with open(prod_list) as fid:
             config = yaml.load(fid.read(), Loader=UnsafeLoader)
-    except (IOError, yaml.YAMLError):
+    except (IOError, yaml.YAMLError, ZMQError):
         # Either open() or yaml.load() failed
         LOG.exception("Process crashed, check YAML file.")
         raise

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -219,13 +219,16 @@ def expand(yml):
 
 def process(msg, prod_list, produced_files):
     """Process a message."""
-    from zmq.error import ZMQError
     config = {}
-
     try:
         with open(prod_list) as fid:
             config = yaml.load(fid.read(), Loader=UnsafeLoader)
+    except (IOError, yaml.YAMLError):
+        # Either open() or yaml.load() failed
+        LOG.exception("Process crashed, check YAML file.")
+        raise
 
+    try:
         config = expand(config)
         jobs = message_to_jobs(msg, config)
         for prio in sorted(jobs.keys()):
@@ -238,13 +241,6 @@ def process(msg, prod_list, produced_files):
                     cwrk.pop('fun')(job, **cwrk)
             except AbortProcessing as err:
                 LOG.info(str(err))
-    except (IOError, yaml.YAMLError):
-        # Either open() or yaml.load() failed
-        LOG.exception("Process crashed, check YAML file.")
-        raise
-    except ZMQError:
-        LOG.exception("Process crashed due to ZMQError")
-        raise
     except Exception:
         LOG.exception("Process crashed")
         if "crash_handlers" in config:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -535,25 +535,9 @@ def check_sunlight_coverage(job):
                 continue
 
             if area_def is None:
-                try:
-                    if 'resampled_scenes' in job:
-                        scn = job['resampled_scenes'][area]
-                    else:
-                        scn = job['scene']
-                    if isinstance(product, tuple):
-                        prod = scn[product[0]]
-                    else:
-                        prod = scn[product]
-                except KeyError:
-                    try:
-                        prod = scn[scn.keys()[0]]
-                    except IndexError:
-                        LOG.warning(
-                            "No dataset %s for this scene and area %s",
-                            product, area)
-                        continue
-
-                area_def = prod.attrs['area']
+                area_def = _get_product_area_def(job, area, product)
+                if area_def is None:
+                    continue
 
             if use_pass:
                 overpass = Pass(platform_name, start_time, end_time, instrument=sensor)
@@ -599,6 +583,28 @@ def _get_sunlight_coverage(area_def, start_time, overpass=None):
         daylight_area = daylight.area()
         total_area = adp.area()
         return daylight_area / total_area
+
+
+def _get_product_area_def(job, area, product):
+    """Get area definition for a product."""
+    try:
+        if 'resampled_scenes' in job:
+            scn = job['resampled_scenes'][area]
+        else:
+            scn = job['scene']
+            if isinstance(product, tuple):
+                prod = scn[product[0]]
+            else:
+                prod = scn[product]
+    except KeyError:
+        try:
+            prod = scn[scn.keys()[0]]
+        except IndexError:
+            LOG.warning("No dataset %s for this scene and area %s",
+                        product, area)
+            return None
+
+    return prod.attrs['area']
 
 
 def add_overviews(job):

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -41,6 +41,7 @@ from satpy.writers import compute_writer_results
 from trollflow2.dict_tools import get_config_value, plist_iter
 from trollsift import compose
 
+
 # Allow trollsched to be missing
 try:
     from trollsched.satpass import Pass
@@ -480,11 +481,17 @@ def sza_check(job):
 
 
 def check_sunlight_coverage(job):
-    """Remove products with too low daytime coverage.
+    """Remove products with too low/high sunlight coverage.
 
-    This plugins looks for a parameter called `min_sunlight_coverage` in the
-    product list, expressed in % (so between 0 and 100). If the sunlit fraction
-    is less than configured, the affected products will be discarded.
+    This plugins looks for a dictionary called `sunlight_coverage` in
+    the product list, with members `min` and/or `max` that define the
+    minimum and/or maximum allowed sunlight coverage within the scene.
+    The limits are expressed in % (so between 0 and 100).  If the
+    sunlit fraction is outside the set limits, the affected products
+    will be discarded.  It is also possible to define `check_pass:
+    True` in this dictionary to check the sunlit fraction within the
+    overpass of an polar-orbiting satellite.
+
     """
     if get_twilight_poly is None:
         LOG.error("Trollsched import failed, sunlight coverage calculation not possible")
@@ -531,6 +538,8 @@ def check_sunlight_coverage(job):
             else:
                 overpass = None
             if min_day is None and max_day is None:
+                LOG.info("Sunlight coverage not configured for %s / %s",
+                         product, area)
                 continue
             coverage = _get_sunlight_coverage(area_def, start_time, overpass)
             product_list['product_list']['areas'][area]['area_sunlight_coverage_percent'] = coverage * 100

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -552,8 +552,8 @@ def check_sunlight_coverage(job):
                             "No dataset %s for this scene and area %s",
                             product, area)
                         continue
-                else:
-                    area_def = prod.attrs['area']
+
+                area_def = prod.attrs['area']
 
             if use_pass:
                 overpass = Pass(platform_name, start_time, end_time, instrument=sensor)

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -537,16 +537,21 @@ def check_sunlight_coverage(job):
             if area_def is None:
                 try:
                     if 'resampled_scenes' in job:
-                        scn_stage = job['resampled_scenes'][area]
+                        scn = job['resampled_scenes'][area]
                     else:
-                        scn_stage = job['scene']
+                        scn = job['scene']
                     if isinstance(product, tuple):
-                        prod = scn_stage[product[0]]
+                        prod = scn[product[0]]
                     else:
-                        prod = scn_stage[product]
+                        prod = scn[product]
                 except KeyError:
-                    LOG.warning("No dataset %s for this scene and area %s", product, area)
-                    continue
+                    try:
+                        prod = scn[scn.keys()[0]]
+                    except IndexError:
+                        LOG.warning(
+                            "No dataset %s for this scene and area %s",
+                            product, area)
+                        continue
                 else:
                     area_def = prod.attrs['area']
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -521,6 +521,8 @@ def check_sunlight_coverage(job):
             area_def = get_area_def(area)
         except AreaNotFound:
             area_def = None
+        coverage = {True: None, False: None}
+        overpass = None
         for product in products:
             prod_path = "/product_list/areas/%s/products/%s" % (area, product)
             config = get_config_value(product_list, prod_path, "sunlight_coverage")
@@ -540,18 +542,20 @@ def check_sunlight_coverage(job):
                 if area_def is None:
                     continue
 
-            if use_pass:
+            if use_pass and overpass is None:
                 overpass = Pass(platform_name, start_time, end_time, instrument=sensor)
-            else:
-                overpass = None
 
-            coverage = _get_sunlight_coverage(area_def, start_time, overpass)
-            product_list['product_list']['areas'][area]['area_sunlight_coverage_percent'] = coverage * 100
-            if min_day is not None and coverage < (min_day / 100.0):
+            if coverage[use_pass] is None:
+                coverage[use_pass] = _get_sunlight_coverage(area_def,
+                                                            start_time,
+                                                            overpass)
+            area_conf = product_list['product_list']['areas'][area]
+            area_conf['area_sunlight_coverage_percent'] = coverage[use_pass] * 100
+            if min_day is not None and coverage[use_pass] < (min_day / 100.0):
                 LOG.info("Not enough sunlight coverage in "
                          "product '%s', removed.", product)
                 dpath.util.delete(product_list, prod_path)
-            if max_day is not None and coverage > (max_day / 100.0):
+            if max_day is not None and coverage[use_pass] > (max_day / 100.0):
                 LOG.info("Too much sunlight coverage in "
                          "product '%s', removed.", product)
                 dpath.util.delete(product_list, prod_path)

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -515,17 +515,8 @@ def check_sunlight_coverage(job):
 
     for area in areas:
         products = list(product_list['product_list']['areas'][area]['products'].keys())
+        area_def = get_area_def(area)
         for product in products:
-            try:
-                if isinstance(product, tuple):
-                    prod = job['resampled_scenes'][area][product[0]]
-                else:
-                    prod = job['resampled_scenes'][area][product]
-            except KeyError:
-                LOG.warning("No dataset %s for this scene and area %s", product, area)
-                continue
-            else:
-                area_def = prod.attrs['area']
             prod_path = "/product_list/areas/%s/products/%s" % (area, product)
             config = get_config_value(product_list, prod_path, "sunlight_coverage")
             if config is None:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -592,13 +592,14 @@ def _get_product_area_def(job, area, product):
             scn = job['resampled_scenes'][area]
         else:
             scn = job['scene']
-            if isinstance(product, tuple):
-                prod = scn[product[0]]
-            else:
-                prod = scn[product]
+
+        if isinstance(product, tuple):
+            prod = scn[product[0]]
+        else:
+            prod = scn[product]
     except KeyError:
         try:
-            prod = scn[scn.keys()[0]]
+            prod = scn[list(scn.keys())[0]]
         except IndexError:
             LOG.warning("No dataset %s for this scene and area %s",
                         product, area)

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -764,6 +764,66 @@ class TestSunlightCovers(TestCase):
                                        0.1)
 
 
+class TestGetProductAreaDef(TestCase):
+    """Test case for finding area definition for a product."""
+
+    def test_get_product_area_def(self):
+        """Test _get_product_area_def()."""
+        from trollflow2.plugins import _get_product_area_def
+        # scn = mock.MagicMock()
+        # scn.__getitem__.side_effect = KeyError
+
+        # No area nor product
+        scn = dict([])
+        job = {'scene': scn}
+        area = 'area'
+        product = 'product'
+        res = _get_product_area_def(job, area, product)
+        self.assertIsNone(res)
+
+        # Area not in the scene, take area def from the available first dataset
+        adef = mock.MagicMock()
+        prod = mock.MagicMock()
+        prod.attrs.__getitem__.return_value = adef
+        scn['1'] = prod
+        job = {'scene': scn}
+        res = _get_product_area_def(job, area, product)
+        self.assertTrue(res is adef)
+        prod.attrs.__getitem__.assert_called_once()
+
+        # Area from the un-resampled scene
+        adef = mock.MagicMock()
+        prod = mock.MagicMock()
+        prod.attrs.__getitem__.return_value = adef
+        prod2 = mock.MagicMock()
+        prod2.attrs.__getitem__.return_value = None
+        scn = {area: prod, '1': prod2}
+        job = {'scene': scn}
+        res = _get_product_area_def(job, area, product)
+        self.assertTrue(res is adef)
+        prod.attrs.__getitem__.assert_called_once()
+        prod2.attrs.__getitem__.assert_not_called()
+        # Product is a tuple
+        res = _get_product_area_def(job, area, (product, 'foo'))
+        self.assertTrue(res is adef)
+
+        # Area from a resampled scene
+        adef = mock.MagicMock()
+        prod = mock.MagicMock()
+        prod.attrs.__getitem__.return_value = adef
+        prod2 = mock.MagicMock()
+        prod2.attrs.__getitem__.return_value = None
+        scn = {area: prod, '1': prod2}
+        job = {'resampled_scenes': {area: scn}}
+        res = _get_product_area_def(job, area, product)
+        self.assertTrue(res is adef)
+        prod.attrs.__getitem__.assert_called_once()
+        prod2.attrs.__getitem__.assert_not_called()
+        # Product is a tuple
+        res = _get_product_area_def(job, area, (product, 'foo'))
+        self.assertTrue(res is adef)
+
+
 class TestCheckSunlightCoverage(TestCase):
     """Test case for sunlight coverage."""
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -753,8 +753,9 @@ class TestSunlightCovers(TestCase):
         """Test sunlight coverage."""
         from trollflow2.plugins import _get_sunlight_coverage
         import numpy as np
-        with mock.patch('trollflow2.plugins.AreaDefBoundary') as area_def_boundary,\
-                mock.patch('trollflow2.plugins.get_twilight_poly'):
+        with mock.patch('trollflow2.plugins.AreaDefBoundary') as area_def_boundary, \
+                mock.patch('trollflow2.plugins.get_twilight_poly'), \
+                mock.patch('trollflow2.plugins.get_area_def'):
 
             area_def_boundary.return_value.contour_poly.intersection.return_value.area.return_value = 0.02
             area_def_boundary.return_value.contour_poly.area.return_value = 0.2


### PR DESCRIPTION
This PR changes the behaviour of `check_sunlight_coverage()` so that it will use the name of area definitions instead of individual composite/channel areas read from resampled scene attributes. This way the filtering can be done before loading and resampling. If the data are not to be projected (area defined as `null` in the config), the area is read from the dataset attributes and the plugin needs to be after the data is loaded with `load_composites`.

Closes https://github.com/pytroll/pyresample/issues/228

 - [x] Tests adjusted and added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
