### PR TITLE
Fix conda channel priority issue

### DIFF
--- a/examples/docker/build_dir/Dockerfile_dev
+++ b/examples/docker/build_dir/Dockerfile_dev
@@ -5,8 +5,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     build-essential
 
 RUN conda config --add channels conda-forge && \
-    conda update conda && \
-    conda install satpy \
+    conda config --set channel_priority true && \
+    conda update --all && \
+    conda install -c conda-forge satpy \
     pyresample \
     pykdtree \
     trollsift \

--- a/examples/docker/build_dir/Dockerfile_stable
+++ b/examples/docker/build_dir/Dockerfile_stable
@@ -4,8 +4,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     gosu
 
 RUN conda config --add channels conda-forge && \
-    conda update conda && \
-    conda install satpy \
+    conda config --set channel_priority true && \
+    conda update --all && \
+    conda install -c conda-forge satpy \
     pyresample \
     pykdtree \
     trollimage \


### PR DESCRIPTION
PR fixes the issue with the conda channel priorities by adding arguments to conda install in the dev and stable Dockerfiles

Bug looked like this:
Traceback (most recent call last):
  File "/opt/conda/bin/satpy_launcher.py", line 27, in <module>
    from trollflow2.launcher import run
  File "/opt/conda/lib/python3.7/site-packages/trollflow2/launcher.py", line 45, in <module>
    from trollflow2.plugins import AbortProcessing
  File "/opt/conda/lib/python3.7/site-packages/trollflow2/plugins/__init__.py", line 31, in <module>
    import rasterio
  File "/opt/conda/lib/python3.7/site-packages/rasterio/__init__.py", line 22, in <module>
    from rasterio._base import gdal_version
ImportError: libpoppler.so.76: cannot open shared object file: No such file or directory