### PR TITLE
Use get_geostationary_bounding_box from pyresample instead of satpy

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -39,7 +39,7 @@ from satpy import Scene
 from satpy.dataset import DatasetID
 from satpy.resample import get_area_def
 from satpy.writers import compute_writer_results
-from satpy.readers.utils import get_geostationary_bounding_box
+from pyresample.geometry import get_geostationary_bounding_box
 from trollflow2.dict_tools import get_config_value, plist_iter
 from trollsift import compose
 


### PR DESCRIPTION
With this PR the imports for GEO bounding box computations are done from Pyresample instead of Satpy. The version there can handle also projections with `ellps` instead of `a/b/h` in the projection definition.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
