### PR TITLE
Implement call to native resampler

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -93,6 +93,8 @@ product_list: &product_list
               # To use add `add_overviews` to workers after `save_datasets`
               # overviews: [4, 8, 16, 32, 64, 128, 256]
     # null:  # satellite projection
+    #   # For satellite projection it is possible to define `resampler: native`
+    #   #   for satellites that have multiple resolutions for a channel
     #   areaname: satellite_projection
     #   # Use lowest listed priority for area in satellite projection.
     #   #   To be able to save the data the composites need to be

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -119,12 +119,15 @@ def resample(job):
             maxarea = get_config_value(product_list,
                                        '/product_list/areas/' + str(area),
                                        'use_max_area')
+            native = conf.get('resampler') == 'native'
             if minarea is True:
                 job['resampled_scenes'][area] = scn.resample(scn.min_area(),
                                                              **area_conf)
             elif maxarea is True:
                 job['resampled_scenes'][area] = scn.resample(scn.max_area(),
                                                              **area_conf)
+            elif native:
+                job['resampled_scenes'][area] = scn.resample(resampler='native')
             else:
                 # The composites need to be created for the saving to work
                 if not set(scn.datasets.keys()).issuperset(scn.wishlist):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -734,6 +734,20 @@ class TestResampleNullArea(TestCase):
         self.assertTrue(mock.call({'abc'}, generate=True) in
                         scn.load.mock_calls)
 
+    def test_resample_native_null_area(self):
+        """Test using `native` resampler with `None` area."""
+        from trollflow2.plugins import resample
+        scn = mock.MagicMock()
+        product_list = self.product_list.copy()
+        product_list["common"] = {"resampler": "native"}
+        job = {"scene": scn, "product_list": product_list.copy()}
+        # The composites have been generated
+        scn.datasets.keys.return_value = ['abc']
+        scn.wishlist = {'abc'}
+        resample(job)
+        self.assertTrue(mock.call(resampler='native') in
+                        scn.resample.mock_calls)
+
 
 class TestSunlightCovers(TestCase):
     """Test the sunlight coverage."""


### PR DESCRIPTION
This PR adds a possibility to call `native` resampler for unprojected (area `None`) scene.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
