### PR TITLE
Add a pluging to check message metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install codecov pytest pytest-cov pyyaml dpath trollsift
+  - pip install codecov pytest pytest-cov pyyaml dpath<1.5 trollsift
 script:
   - pytest --cov=./
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install codecov pytest pytest-cov pyyaml dpath<1.5 trollsift
+  - pip install codecov pytest pytest-cov pyyaml "dpath<1.5" trollsift
 script:
   - pytest --cov=./
 after_success:

--- a/examples/docker/config_ears_avhrr/trollflow2_ears_avhrr.yaml
+++ b/examples/docker/config_ears_avhrr/trollflow2_ears_avhrr.yaml
@@ -17,8 +17,10 @@ product_list:
   metadata_aliases:
     sensor:
       avhrr/3: avhrr-3
-  # Process only these platforms
-  processed_platforms:
+  # Check that metadata matches
+  check_metadata:
+    # Only these platforms are processed
+    platform_name:
     - NOAA-19
     - Metop-A
     - Metop-B

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools import setup
 import versioneer
 import sys
 
-install_requires = ['pyyaml', 'dpath', 'trollsift']
+install_requires = ['pyyaml', 'dpath<1.5', 'trollsift']
 if "test" not in sys.argv:
     install_requires += ['posttroll', 'satpy', 'pyorbital']
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -425,7 +425,7 @@ def check_sensor(job):
     """Check if the sensor is valid.  If not, discard the scene."""
     mda = job['input_mda']
     product_list = job['product_list']
-    conf = get_config_value(product_list, '/product_list', 'processed_platforms')
+    conf = get_config_value(product_list, '/product_list', 'processed_sensors')
     if conf is None:
         return
     sensor = mda['sensor']

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+#
 # Copyright (c) 2019 Pytroll developers
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
-
+#
 # Workaround for unittests so that satpy and posttroll installations
 # are not necessary
 
@@ -419,6 +419,19 @@ def check_platform(job):
     if platform not in conf:
         raise AbortProcessing(
             "'%s' not in list of allowed platforms" % platform)
+
+
+def check_sensor(job):
+    """Check if the sensor is valid.  If not, discard the scene."""
+    mda = job['input_mda']
+    product_list = job['product_list']
+    conf = get_config_value(product_list, '/product_list', 'processed_platforms')
+    if conf is None:
+        return
+    sensor = mda['sensor']
+    if sensor not in conf:
+        raise AbortProcessing(
+            "'%s' not in list of allowed sensors" % str(sensor))
 
 
 def metadata_alias(job):

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -408,30 +408,26 @@ def get_scene_coverage(platform_name, start_time, end_time, sensor, area_id):
     return 100 * overpass.area_coverage(area_def)
 
 
-def check_platform(job):
-    """Check if the platform is valid.  If not, discard the scene."""
+def check_metadata(job):
+    """Check the message metadata.
+
+    If the metadata does not match the configured values, the scene
+    will be discarded.
+
+    """
     mda = job['input_mda']
     product_list = job['product_list']
-    conf = get_config_value(product_list, '/product_list', 'processed_platforms')
+    conf = get_config_value(product_list, '/product_list', 'check_metadata')
     if conf is None:
         return
-    platform = mda['platform_name']
-    if platform not in conf:
-        raise AbortProcessing(
-            "'%s' not in list of allowed platforms" % platform)
-
-
-def check_sensor(job):
-    """Check if the sensor is valid.  If not, discard the scene."""
-    mda = job['input_mda']
-    product_list = job['product_list']
-    conf = get_config_value(product_list, '/product_list', 'processed_sensors')
-    if conf is None:
-        return
-    sensor = mda['sensor']
-    if sensor not in conf:
-        raise AbortProcessing(
-            "'%s' not in list of allowed sensors" % str(sensor))
+    for key, val in conf.items():
+        if key not in mda:
+            LOG.warning("Metadata item '%s' not in the input message.",
+                        key)
+            continue
+        if mda[key] not in val:
+            raise AbortProcessing("Metadata '%s' item '%s' not in '%s'" %
+                                  (key, mda[key], str(val)))
 
 
 def metadata_alias(job):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1047,6 +1047,24 @@ class TestCheckPlatform(TestCase):
                 check_platform(job)
 
 
+class TestCheckSensor(TestCase):
+    """Test case for checking the sensor."""
+
+    def test_check_sensor(self):
+        """Test checking the platform."""
+        from trollflow2.plugins import check_sensor
+        from trollflow2.plugins import AbortProcessing
+        with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
+            get_config_value.return_value = None
+            job = {'product_list': None, 'input_mda': {'sensor': 'foo'}}
+            self.assertIsNone(check_sensor(job))
+            get_config_value.return_value = ['foo', 'bar']
+            self.assertIsNone(check_sensor(job))
+            get_config_value.return_value = ['bar']
+            with self.assertRaises(AbortProcessing):
+                check_sensor(job)
+
+
 class TestMetadataAlias(TestCase):
     """Test case for metadata alias."""
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1029,40 +1029,47 @@ class TestCovers(TestCase):
             covers(job)
 
 
-class TestCheckPlatform(TestCase):
-    """Test case for checking the platform."""
+class TestCheckMetadata(TestCase):
+    """Test case for checking the input metadata."""
 
-    def test_check_platform(self):
-        """Test checking the platform."""
-        from trollflow2.plugins import check_platform
-        from trollflow2.plugins import AbortProcessing
-        with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
-            get_config_value.return_value = None
-            job = {'product_list': None, 'input_mda': {'platform_name': 'foo'}}
-            self.assertIsNone(check_platform(job))
-            get_config_value.return_value = ['foo', 'bar']
-            self.assertIsNone(check_platform(job))
-            get_config_value.return_value = ['bar']
-            with self.assertRaises(AbortProcessing):
-                check_platform(job)
-
-
-class TestCheckSensor(TestCase):
-    """Test case for checking the sensor."""
-
-    def test_check_sensor(self):
-        """Test checking the platform."""
-        from trollflow2.plugins import check_sensor
+    def test_single_item(self):
+        """Test checking a single metadata item."""
+        from trollflow2.plugins import check_metadata
         from trollflow2.plugins import AbortProcessing
         with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
             get_config_value.return_value = None
             job = {'product_list': None, 'input_mda': {'sensor': 'foo'}}
-            self.assertIsNone(check_sensor(job))
-            get_config_value.return_value = ['foo', 'bar']
-            self.assertIsNone(check_sensor(job))
-            get_config_value.return_value = ['bar']
+            self.assertIsNone(check_metadata(job))
+            get_config_value.return_value = {'sensor': ['foo', 'bar']}
+            self.assertIsNone(check_metadata(job))
+            get_config_value.return_value = {'sensor': ['bar']}
             with self.assertRaises(AbortProcessing):
-                check_sensor(job)
+                check_metadata(job)
+
+    def test_multiple_items(self):
+        """Test checking a single metadata item."""
+        from trollflow2.plugins import check_metadata
+        from trollflow2.plugins import AbortProcessing
+        with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
+            # Nothing configured
+            get_config_value.return_value = None
+            job = {'product_list': None,
+                   'input_mda': {'sensor': 'foo',
+                                 'platform_name': 'bar'}}
+            self.assertIsNone(check_metadata(job))
+            # Both sensor and platform name match
+            get_config_value.return_value = {'sensor': ['foo', 'bar'],
+                                             'platform_name': ['bar']}
+            self.assertIsNone(check_metadata(job))
+            # Sensor matches, 'variant' not in the message
+            get_config_value.return_value = {'sensor': ['foo', 'bar'],
+                                             'variant': ['e ascari']}
+            self.assertIsNone(check_metadata(job))
+            # Platform doesn't match -> abort
+            get_config_value.return_value = {'sensor': ['foo'],
+                                             'platform_name': ['not-bar']}
+            with self.assertRaises(AbortProcessing):
+                check_metadata(job)
 
 
 class TestMetadataAlias(TestCase):


### PR DESCRIPTION
This PR adds a plugin that can be used to check the sensor given in the message metadata.

This is needed when handling messages coming from `aapp_dr_runner` which basically needs to use the same topics for every sensor.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
