### PR TITLE
Add the info parameter to `format`

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -270,6 +270,10 @@ Product list
  - ``productname``, ``areaname`` are the names to use for product and area
    in the filename. If not provided, they default to the actual product
    and area names.
+ - Each ``format`` in the ``formats`` section can have an ``info`` item to store
+   information that will be strictly kept in the product list (ie not saved to
+   file, not published). This can be useful for example for storing information
+   about which customer is receiving this file in the end.
 
 Example
 *******
@@ -324,6 +328,8 @@ Example
               - format: nc
                 writer: cf
                 fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
+                info:
+                  clients: [The ice services]
           green_snow:
             sunlight_coverage:
               min: 10

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -65,6 +65,10 @@ product_list: &product_list
           formats:
             - format: nc
               writer: cf
+              # you can have some info about this file here, that won't leave
+              # the product list.
+              info:
+                clients: [The IR Times, John Doe]
           # Remove product if SZA is more than this
           #sunzen_maximum_angle: 90.0
           # Remove product if sunligth coverage is less that this

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -193,6 +193,7 @@ def save_dataset(scns, fmat, fmat_config, renames):
             kwargs = fmat_config.copy()
             kwargs.pop('fname_pattern', None)
             kwargs.pop('dispatch', None)
+            kwargs.pop('info', None)
             if isinstance(fmat['product'], (tuple, list, set)):
                 kwargs.pop('format')
                 dsids = []

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -183,6 +183,8 @@ product_list:
               - format: jpg
                 writer: simple_image
                 fill_value: 0
+                info:
+                  client: [Important client, Newspaper]
             fname_pattern: "{platform_name:s}_{start_time:%Y%m%d_%H%M}_{areaname:s}_ctth_static.{format}"
           ("ct", "ctth"):
             productname: ct_and_ctth
@@ -433,7 +435,9 @@ class TestSaveDatasets(TestCase):
                                  'format':
                                  'jpg',
                                  'writer':
-                                 'simple_image'
+                                 'simple_image',
+                                 'info':
+                                    {'client': ['Important client', 'Newspaper']},
                              }],
                             'output_dir':
                             '/tmp/satdmz/pps/www/latest_2018/',


### PR DESCRIPTION
This PR adds an `info` field in the `format` sections. This field is not getting out of the product list in any way, but the reason it is not a comment is because we want to be able to manipulate it with a yaml library in the future (for example to be able to modify the product list with a UI).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
