### PR TITLE
setting mtime of finished file for detection of newly created products

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -22,6 +22,7 @@
 """Trollflow2 plugins."""
 
 import os
+from pathlib import Path
 from contextlib import contextmanager
 from logging import getLogger
 from tempfile import NamedTemporaryFile
@@ -221,6 +222,7 @@ def renamed_files():
     yield renames
 
     for tmp_name, actual_name in renames.items():
+        Path(tmp_name).touch()    # update mtime before renaming to real filename for dist. tools
         os.rename(tmp_name, actual_name)
 
 


### PR DESCRIPTION
update mtime before renaming to real filename for distribution tools that recognize new files based on file age

**modify mtime of created product with touch() from pathlib for dist. tools**

When using `use_tmp_file = True` in trollflow2 yaml products will be created with a tempfile. The duration of the begin of creating the file and finish writing can be a relatively long period of time; sometimes up to 40 minutes (NOAA-20, S-NPP).

DWD uses a file distribution system, which distribute new files to a number of customers. Only new products should be distributed. We recognize new files by the modification time by using the find command (e.g. -mmin 1).
The finished product will have the timestamp of file **creation**.
So with long creation durations the distribution program doesn't recognize such products as new files any more and there will be no distribution to our customers.

The desired behaviour is like the `touch` command in Linux.
After the file is completely written, the file mtime should be updated, to indicate, that it is a new file.

No compatibilty breaks expected.
