### PR TITLE
Add support to dask.distributed

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -1,3 +1,11 @@
+# Use external scheduler.  This example uses dask.distributed.Client,
+#   but any other class can be used as long as it returns a client and
+#   registers itself to dask.  The `settings` are passed as keyword
+#   arguments to the class when instantiated.
+# dask_distributed:
+#   class: !!python/name:dask.distributed.Client
+#   settings:
+#     address: localhost:8786
 
 product_list: &product_list
   output_dir: &output_dir

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -217,6 +217,29 @@ def expand(yml):
     return yml
 
 
+def get_dask_client(config):
+    """Create Dask client if configured."""
+    client = None
+
+    try:
+        client_class = config["dask_distributed"]["class"]
+        client = client_class(**config["dask_distributed"]["settings"])
+        try:
+            if not client.ncores():
+                LOG.error("No workers available, reverting to default scheduler")
+                client.close()
+                client = None
+        except AttributeError:
+            pass
+    except OSError:
+        LOG.error("Scheduler not found, reverting to default scheduler")
+    except KeyError:
+        LOG.info("Distributed processing not configured, "
+                 "using default scheduler")
+
+    return client
+
+
 def process(msg, prod_list, produced_files):
     """Process a message."""
     config = {}
@@ -227,6 +250,9 @@ def process(msg, prod_list, produced_files):
         # Either open() or yaml.load() failed
         LOG.exception("Process crashed, check YAML file.")
         raise
+
+    # Get distributed client
+    client = get_dask_client(config)
 
     try:
         config = expand(config)
@@ -258,6 +284,10 @@ def process(msg, prod_list, produced_files):
             except AttributeError:
                 continue
         del config
+        try:
+            client.close()
+        except AttributeError:
+            pass
         gc.collect()
 
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -223,7 +223,8 @@ def get_dask_client(config):
 
     try:
         client_class = config["dask_distributed"]["class"]
-        client = client_class(**config["dask_distributed"]["settings"])
+        settings = config["dask_distributed"].get("settings", {})
+        client = client_class(**settings)
         try:
             if not client.ncores():
                 LOG.error("No workers available, reverting to default scheduler")

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -230,7 +230,7 @@ def get_dask_client(config):
                 client.close()
                 client = None
         except AttributeError:
-            pass
+            client = None
     except OSError:
         LOG.error("Scheduler not found, reverting to default scheduler")
     except KeyError:

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -227,7 +227,7 @@ def get_dask_client(config):
         client = client_class(**settings)
         try:
             if not client.ncores():
-                LOG.error("No workers available, reverting to default scheduler")
+                LOG.warning("No workers available, reverting to default scheduler")
                 client.close()
                 client = None
         except AttributeError:

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -290,7 +290,9 @@ class TestProcess(TestCase):
             mock_config = mock.MagicMock()
             yaml_.load.return_value = mock_config
             yaml_.YAMLError = yaml.YAMLError
+            # Make a client that has no `.close()` method (for coverage)
             client = mock.MagicMock()
+            client.close.side_effect = AttributeError
             gdc.return_value = client
             fun1 = mock.MagicMock()
             # Return something resembling a config

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -338,7 +338,8 @@ class TestProcess(TestCase):
                 process("msg", "prod_list", the_queue)
 
 
-def test_get_dask_client():
+@mock.patch("trollflow2.plugins")
+def test_get_dask_client(plugins):
     """Test getting dask client."""
     from trollflow2.launcher import get_dask_client
 

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -368,17 +368,22 @@ class TestDistributed(TestCase):
         ncores.assert_called_once()
         client.close.assert_called_once()
 
+        # The scheduler had no workers, the client doesn't have `.close()`
+        client.close.side_effect = AttributeError
+        res = get_dask_client(config)
+        assert res is None
+
         # Config is valid, scheduler has workers
         ncores.return_value = {'a': 1, 'b': 1}
         res = get_dask_client(config)
         assert res is client
-        assert ncores.call_count == 2
+        assert ncores.call_count == 3
 
         # Scheduler couldn't connect to workers
         client_class.side_effect = OSError
         res = get_dask_client(config)
         assert res is None
-        assert ncores.call_count == 2
+        assert ncores.call_count == 3
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR makes it possible to use `dask.distributed` with trollflow2. The example config (below, defined in the trollflow2 config file) uses `dask.distributed.Client` to connect to a scheduler and associated workers. If `dask_distributed` isn't in the configuration, the default scheduler is used. This is hopefully generic enough to meet the idea @djhoese gave in #82 for the user to define their own scheduling/cluster classes.

```yaml
dask_distributed:
  class: !!python/name:dask.distributed.Client
  settings:
    address: localhost:8786
```

 - [x] Closes #82 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
