### PR TITLE
Upgrade packages on travis installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.6"
   - "3.7"
 install:
-  - pip install codecov pytest pytest-cov pyyaml "dpath<1.5" trollsift
+  - pip install -U codecov pytest pytest-cov pyyaml "dpath<1.5" trollsift
 script:
   - pytest --cov=./
 after_success:


### PR DESCRIPTION
Tests are failing on travis because of an old pytest being already installed.

 - [x] Tests passed <!-- for all non-documentation changes -->

