### PR TITLE
Fix null resampling with newer versions of satpy

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -133,7 +133,7 @@ def resample(job):
                 job['resampled_scenes'][area] = scn.resample(resampler='native')
             else:
                 # The composites need to be created for the saving to work
-                if not set(scn.datasets.keys()).issuperset(scn.wishlist):
+                if not set(scn.keys()).issuperset(scn.wishlist):
                     LOG.debug("Generating composites for 'null' area (satellite projection).")
                     scn.load(scn.wishlist, generate=True)
                 job['resampled_scenes'][area] = scn

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -723,12 +723,12 @@ class TestResampleNullArea(TestCase):
         product_list = self.product_list.copy()
         job = {"scene": scn, "product_list": product_list.copy()}
         # The composites have been generated
-        scn.datasets.keys.return_value = ['abc']
+        scn.keys.return_value = ['abc']
         scn.wishlist = {'abc'}
         resample(job)
         scn.load.assert_not_called()
         # The composites have not been generated
-        scn.datasets.keys.return_value = ['a', 'b', 'c']
+        scn.keys.return_value = ['a', 'b', 'c']
         scn.wishlist = {'abc'}
         resample(job)
         self.assertTrue(mock.call({'abc'}, generate=True) in
@@ -742,7 +742,7 @@ class TestResampleNullArea(TestCase):
         product_list["common"] = {"resampler": "native"}
         job = {"scene": scn, "product_list": product_list.copy()}
         # The composites have been generated
-        scn.datasets.keys.return_value = ['abc']
+        scn.keys.return_value = ['abc']
         scn.wishlist = {'abc'}
         resample(job)
         self.assertTrue(mock.call(resampler='native') in


### PR DESCRIPTION
Satpy 0.23 privatized the `.datasets` attribute of the scene, and thus broke some parts of trollflow2 that used it. This PR fixes it.

 - [x] Closes #88 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
