### PR TITLE
Add the aggregate plugin

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -79,6 +79,22 @@ special keyword arguments:
    resampling.  This can save a lot of time if the same channels are
    used in several composites.  Default: ``True``.
 
+Aggregate
+*********
+
+In some cases, large scenes need to be aggregated down to a lower resolution.
+
+To use this plugin, just add the `aggregate` keyword in the product list's top level
+and provide under it the dimension parameters to pass to the corresponding satpy function.
+For example::
+
+  product_list:
+    aggregate:
+      x: 2
+      y: 2
+
+will aggregate using 2x2 pixel blocks.
+
 Resampling
 **********
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -99,6 +99,14 @@ def load_composites(job):
     job['scene'] = scn
 
 
+def aggregate(job):
+    """Aggregate the chosen composites."""
+    if 'aggregate' not in job['product_list']['product_list']:
+        return
+    kwargs = job['product_list']['product_list']['aggregate']
+    job['scene'] = job['scene'].aggregate(**kwargs)
+
+
 def resample(job):
     """Resample the scene to some areas."""
     defaults = {"radius_of_influence": None,


### PR DESCRIPTION
Working with SAR IW data, the data is simply to large to be useful. This plugin gives the possibility to aggregate the data before it's processed further.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
