### PR TITLE
Add possibility to provide a jsonified filesystem spec in the message

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -210,6 +210,12 @@ def _extract_filenames(msg):
     If the message contains a `filesystem` item, use fsspec to decode it.
     """
     filenames = [urlparse(uri).path for uri in gen_dict_extract(msg.data, 'uri')]
+    filenames = _create_fs_file_instances(filenames, msg)
+    return filenames
+
+
+def _create_fs_file_instances(filenames, msg):
+    """Create FSFile instances when filesystem is provided."""
     filesystems = list(gen_dict_extract(msg.data, 'filesystem'))
     if filesystems:
         from satpy.readers import FSFile

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
@@ -24,7 +23,9 @@
 """Test the launcher module."""
 
 import unittest
+
 import yaml
+
 try:
     from yaml import UnsafeLoader
 except ImportError:
@@ -192,6 +193,37 @@ class TestMessageToJobs(TestCase):
                          prods['natural_color']['formats'][0])
         prods['overview']['formats'][0]['foo'] = 'bar'
         self.assertFalse('foo' in prods['natural_color']['formats'][0])
+
+    @mock.patch('fsspec.spec.AbstractFileSystem')
+    @mock.patch('satpy.readers.FSFile')
+    def test_message_to_jobs_fsspec(self, fsfile, abs_fs):
+        """Test transforming a message containing filesystem specification."""
+        from trollflow2.launcher import message_to_jobs
+        import json
+
+        filename = "/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc"  # noqa
+        fs = {"cls": "fsspec.implementations.zip.ZipFileSystem",
+              "protocol": "abstract",
+              "args": ["sentinel-s3-ol2wfr-zips/2020/12/10/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.zip"],  # noqa
+              "target_protocol": "s3",
+              "target_options": {"anon": False,
+                                 "client_kwargs": {"endpoint_url": "https://my.dismi.se"}}}
+        msg_data = {"dataset": [{"filesystem": fs,
+                                 "uid": "zip:///S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc::s3:///sentinel-s3-ol2wfr-zips/2020/12/10/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.zip",  # noqa
+                                 "uri": "zip://" + filename
+                                 }]
+                    }
+
+        msg = mock.MagicMock()
+        msg.data = msg_data
+
+        prodlist = yaml.load(yaml_test_minimal, Loader=UnsafeLoader)
+        jobs = message_to_jobs(msg, prodlist)
+        filesystemfile = jobs[999]['input_filenames'][0]
+
+        assert filesystemfile == fsfile.return_value
+        fsfile.assert_called_once_with(filename, abs_fs.from_json.return_value)
+        abs_fs.from_json.assert_called_once_with(json.dumps(fs))
 
 
 class TestRun(TestCase):


### PR DESCRIPTION
This PR add the functionality of creating a (fsspec) filesystem object to be provided in a `satpy.FSFile` instance to pass to satpy.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
