### PR TITLE
Adapt trollflow2 for removal of ppp_config_dir

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@ The following people have made contributions to this project:
 - [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
+- [Gerrit Holl (gerritholl)](https://github.com/gerritholl)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,6 @@ The following people have made contributions to this project:
 <!--- The list should be alphabetical by last name if possible, with github usernames at the bottom --->
 
 - [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
+- [Gerrit Holl (gerritholl)](https://github.com/gerritholl)
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
-- [Gerrit Holl (gerritholl)](https://github.com/gerritholl)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,8 +58,11 @@ options are:
    given, Satpy will try to find the reader automatically.
  - ``reader_kwargs`` - A dictionary of special keyword arguments passed
    to the reader.
- - ``ppp_config_dir`` - Path to the Pytroll configuration directory.
-   If not given, environment variable ``$PPP_CONFIG_DIR`` is used.
+
+For old Satpy versions (before Satpy 0.26), there is additionally the
+``ppp_config_dir`` option, for the path to the Pytroll configuration directory.
+If not given, environment variable ``$PPP_CONFIG_DIR`` is used.  For newer
+Satpy versions, users must set the ``$SATPY_CONFIG_PATH`` environment variable.
 
 This plugin needs to be defined before data are accessed in any way.
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -68,8 +68,10 @@ class AbortProcessing(Exception):
 def create_scene(job):
     """Create a satpy scene."""
     defaults = {'reader': None,
-                'reader_kwargs': None,
-                'ppp_config_dir': None}
+                'reader_kwargs': None}
+    from satpy.version import version as satpy_version
+    if satpy_version <= "0.25.1":
+        defaults['ppp_config_dir'] = None
     product_list = job['product_list']
     conf = _get_plugin_conf(product_list, '/product_list', defaults)
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -38,6 +38,7 @@ from rasterio.enums import Resampling
 from satpy import Scene
 from satpy.resample import get_area_def
 from satpy.writers import compute_writer_results
+from satpy.version import version as satpy_version
 from pyresample.geometry import get_geostationary_bounding_box
 from trollflow2.dict_tools import get_config_value, plist_iter
 from trollsift import compose
@@ -69,7 +70,6 @@ def create_scene(job):
     """Create a satpy scene."""
     defaults = {'reader': None,
                 'reader_kwargs': None}
-    from satpy.version import version as satpy_version
     if satpy_version <= "0.25.1":
         defaults['ppp_config_dir'] = None
     product_list = job['product_list']

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -531,18 +531,27 @@ class TestCreateScene(TestCase):
     def test_create_scene(self):
         """Test making a scene."""
         from trollflow2.plugins import create_scene
-        with mock.patch("trollflow2.plugins.Scene") as scene:
+        from satpy.version import version as satpy_version
+        with mock.patch("trollflow2.plugins.Scene", autospec=True) as scene:
             scene.return_value = "foo"
             job = {"input_filenames": "bar", "product_list": {}}
             create_scene(job)
             self.assertEqual(job["scene"], "foo")
-            scene.assert_called_with(filenames='bar', reader=None,
-                                     reader_kwargs=None, ppp_config_dir=None)
+            if satpy_version <= "0.25.1":
+                scene.assert_called_with(filenames='bar', reader=None,
+                                         reader_kwargs=None, ppp_config_dir=None)
+            else:
+                scene.assert_called_with(filenames='bar', reader=None,
+                                         reader_kwargs=None)
             job = {"input_filenames": "bar",
                    "product_list": {"product_list": {"reader": "baz"}}}
             create_scene(job)
-            scene.assert_called_with(filenames='bar', reader='baz',
-                                     reader_kwargs=None, ppp_config_dir=None)
+            if satpy_version <= "0.25.1":
+                scene.assert_called_with(filenames='bar', reader='baz',
+                                         reader_kwargs=None, ppp_config_dir=None)
+            else:
+                scene.assert_called_with(filenames='bar', reader='baz',
+                                         reader_kwargs=None)
 
 
 class TestLoadComposites(TestCase):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -531,10 +531,11 @@ class TestCreateScene(TestCase):
     def test_create_scene(self):
         """Test making a scene."""
         from trollflow2.plugins import create_scene
-        try:
-            from satpy.version import version as satpy_version
-        except ImportError:
-            satpy_version = "0.26.0"
+        from satpy.version import version as satpy_version
+        if not isinstance(satpy_version, str):
+            # trollflow2 mocks all missing imports
+            import trollflow2.plugins
+            trollflow2.plugins.satpy_version = satpy_version = "0.26.0"
         with mock.patch("trollflow2.plugins.Scene", autospec=True) as scene:
             scene.return_value = "foo"
             job = {"input_filenames": "bar", "product_list": {}}

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -531,7 +531,10 @@ class TestCreateScene(TestCase):
     def test_create_scene(self):
         """Test making a scene."""
         from trollflow2.plugins import create_scene
-        from satpy.version import version as satpy_version
+        try:
+            from satpy.version import version as satpy_version
+        except ImportError:
+            satpy_version = "0.26.0"
         with mock.patch("trollflow2.plugins.Scene", autospec=True) as scene:
             scene.return_value = "foo"
             job = {"input_filenames": "bar", "product_list": {}}


### PR DESCRIPTION
Adapt the trollflow2 `create_scene` plugin for the removal of
ppp_config_dir.  Fixes #96.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #96 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Add your name to `AUTHORS.md` if not there already
