### PR TITLE
Add area name to "area kept" log message

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -409,8 +409,8 @@ def covers(job):
             dpath.util.delete(product_list, area_path)
 
         else:
-            LOG.debug("Area coverage %.2f %% above threshold %.2f %% - Carry on",
-                      cov, min_coverage)
+            LOG.debug(f"Area coverage {cov:.2f}% above threshold "
+                      f"{min_coverage:.2f}% - Carry on with {area:s}")
 
     job['product_list'] = product_list
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -23,8 +23,8 @@
 """Test plugins."""
 
 import datetime as dt
-import os
 import logging
+import os
 import unittest
 from unittest import mock
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -24,6 +24,7 @@
 
 import datetime as dt
 import os
+import logging
 import unittest
 from unittest import mock
 
@@ -1002,7 +1003,10 @@ class TestCovers(TestCase):
             job = {"product_list": self.product_list,
                    "input_mda": self.input_mda,
                    "scene": scn}
-            covers(job)
+            with self.assertLogs("trollflow2.plugins", logging.DEBUG) as log:
+                covers(job)
+            assert ("DEBUG:trollflow2.plugins:Area coverage 10.00% "
+                    "above threshold 5.00% - Carry on with omerc_bb" in log.output)
             # Area "euron1" should be removed
             self.assertFalse("euron1" in job['product_list']['product_list']['areas'])
             # Other areas should stay in the list


### PR DESCRIPTION
When logging a debug message that an area is kept because of sufficient
area coverage, add the name of the area.

This will break backward compatibility with systems searching for this exact log message.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #101 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
