### PR TITLE
Remove the ppp_config_dir scene creation parameter for satpy>=0.26.0 compatibility

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,8 +58,6 @@ options are:
    given, Satpy will try to find the reader automatically.
  - ``reader_kwargs`` - A dictionary of special keyword arguments passed
    to the reader.
- - ``ppp_config_dir`` - Path to the Pytroll configuration directory.
-   If not given, environment variable ``$PPP_CONFIG_DIR`` is used.
 
 This plugin needs to be defined before data are accessed in any way.
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -68,8 +68,7 @@ class AbortProcessing(Exception):
 def create_scene(job):
     """Create a satpy scene."""
     defaults = {'reader': None,
-                'reader_kwargs': None,
-                'ppp_config_dir': None}
+                'reader_kwargs': None}
     product_list = job['product_list']
     conf = _get_plugin_conf(product_list, '/product_list', defaults)
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -540,13 +540,11 @@ class TestCreateScene(TestCase):
             job = {"input_filenames": "bar", "product_list": {}}
             create_scene(job)
             self.assertEqual(job["scene"], "foo")
-            scene.assert_called_with(filenames='bar', reader=None,
-                                     reader_kwargs=None, ppp_config_dir=None)
+            scene.assert_called_with(filenames='bar', reader=None, reader_kwargs=None)
             job = {"input_filenames": "bar",
                    "product_list": {"product_list": {"reader": "baz"}}}
             create_scene(job)
-            scene.assert_called_with(filenames='bar', reader='baz',
-                                     reader_kwargs=None, ppp_config_dir=None)
+            scene.assert_called_with(filenames='bar', reader='baz', reader_kwargs=None)
 
 
 class TestLoadComposites(TestCase):


### PR DESCRIPTION
As of satpy 0.26.0, the scene creation doesn't accept the `ppp_config_dir` parameter anymore.
This PR removes it, since the prefered usage is to path `SATPY_CONFIG_DIR` as an environment variable now.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
