### PR TITLE
Make it possible to use `FilePublisher` without running a nameserver

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -30,7 +30,7 @@ from urllib.parse import urlunsplit
 import dpath
 import rasterio
 from posttroll.message import Message
-from posttroll.publisher import NoisyPublisher
+from posttroll.publisher import Publisher, NoisyPublisher
 from pyorbital.astronomy import sun_zenith_angle
 from pyresample.boundary import AreaDefBoundary, Boundary
 from pyresample.area_config import AreaNotFound
@@ -268,7 +268,7 @@ def save_datasets(job):
 class FilePublisher(object):
     """Publisher for generated files."""
 
-    def __init__(self, port=0, nameservers=None):
+    def __init__(self, port=0, nameservers=""):
         """Create new instance."""
         self.pub = None
         self.port = port
@@ -279,10 +279,13 @@ class FilePublisher(object):
         """Set things running even when loading from YAML."""
         LOG.debug('Starting publisher')
         self.port = kwargs.get('port', 0)
-        self.nameservers = kwargs.get('nameservers', None)
-        self.pub = NoisyPublisher('l2processor', port=self.port,
-                                  nameservers=self.nameservers)
-        self.pub.start()
+        self.nameservers = kwargs.get('nameservers', "")
+        if self.nameservers is None:
+            self.pub = Publisher("tcp://*:" + str(self.port), "l2processor")
+        else:
+            self.pub = NoisyPublisher('l2processor', port=self.port,
+                                      nameservers=self.nameservers)
+            self.pub.start()
 
     @staticmethod
     def create_message(fmat, mda):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1285,38 +1285,40 @@ class TestFilePublisher(TestCase):
         from trollflow2.dict_tools import plist_iter
         from trollsift import compose
         import os.path
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher'):
-            pub = FilePublisher()
-            pub.pub.start.assert_called_once()
-            product_list = self.product_list.copy()
-            product_list['product_list']['publish_topic'] = '/{areaname}/{productname}'
-            job = {'product_list': product_list,
-                   'input_mda': self.input_mda}
-            topic_pattern = job['product_list']['product_list']['publish_topic']
-            topics = []
-            # Create filenames and topics
-            for fmat, fmat_config in plist_iter(job['product_list']['product_list'],
-                                                job['input_mda'].copy()):
-                fname_pattern = fmat['fname_pattern']
-                filename = compose(os.path.join(fmat['output_dir'],
-                                                fname_pattern), fmat)
-                fmat.pop('format', None)
-                fmat_config['filename'] = filename
-                topics.append(compose(topic_pattern, fmat))
+        with mock.patch('trollflow2.plugins.Message') as message:
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher'):
+                    pub = FilePublisher()
+                    pub.pub.start.assert_called_once()
+                    product_list = self.product_list.copy()
+                    product_list['product_list']['publish_topic'] = '/{areaname}/{productname}'
+                    job = {'product_list': product_list,
+                        'input_mda': self.input_mda}
+                    topic_pattern = job['product_list']['product_list']['publish_topic']
+                    topics = []
+                    # Create filenames and topics
+                    for fmat, fmat_config in plist_iter(job['product_list']['product_list'],
+                                                        job['input_mda'].copy()):
+                        fname_pattern = fmat['fname_pattern']
+                        filename = compose(os.path.join(fmat['output_dir'],
+                                                        fname_pattern), fmat)
+                        fmat.pop('format', None)
+                        fmat_config['filename'] = filename
+                        topics.append(compose(topic_pattern, fmat))
 
-            pub(job)
-            message.assert_called()
-            pub.pub.send.assert_called()
-            pub.__del__()
-            pub.pub.stop.assert_called()
-            i = 0
-            for area in job['product_list']['product_list']['areas']:
-                for _prod in job['product_list']['product_list']['areas'][area]:
-                    # Skip calls to __str__
-                    if 'call().__str__()' != str(message.mock_calls[i]):
-                        self.assertTrue(topics[i] in str(message.mock_calls[i]))
-                        i += 1
-            self.assertEqual(message.call_args[0][2]['processing_center'], 'SMHI')
+                    pub(job)
+                    message.assert_called()
+                    pub.pub.send.assert_called()
+                    pub.__del__()
+                    pub.pub.stop.assert_called()
+                    i = 0
+                    for area in job['product_list']['product_list']['areas']:
+                        for _prod in job['product_list']['product_list']['areas'][area]:
+                            # Skip calls to __str__
+                            if 'call().__str__()' != str(message.mock_calls[i]):
+                                self.assertTrue(topics[i] in str(message.mock_calls[i]))
+                                i += 1
+                    self.assertEqual(message.call_args[0][2]['processing_center'], 'SMHI')
 
     def test_filepublisher_without_compose(self):
         """Test filepublisher without compose."""
@@ -1324,24 +1326,26 @@ class TestFilePublisher(TestCase):
         from trollflow2.dict_tools import plist_iter
         from trollsift import compose
         import os.path
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher'):
-            pub = FilePublisher()
-            pub.pub.start.assert_called_once()
-            product_list = self.product_list.copy()
-            product_list['product_list']['publish_topic'] = '/static_topic'
-            job = {'product_list': product_list,
-                   'input_mda': self.input_mda}
-            topic_pattern = job['product_list']['product_list']['publish_topic']
-            topics = []
-            # Create filenames and topics
-            for fmat, fmat_config in plist_iter(job['product_list']['product_list'],
-                                                job['input_mda'].copy()):
-                fname_pattern = fmat['fname_pattern']
-                filename = compose(os.path.join(fmat['output_dir'],
-                                                fname_pattern), fmat)
-                fmat.pop('format', None)
-                fmat_config['filename'] = filename
-                topics.append(compose(topic_pattern, fmat))
+        with mock.patch('trollflow2.plugins.Message') as message:
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher'):
+                    pub = FilePublisher()
+                    pub.pub.start.assert_called_once()
+                    product_list = self.product_list.copy()
+                    product_list['product_list']['publish_topic'] = '/static_topic'
+                    job = {'product_list': product_list,
+                        'input_mda': self.input_mda}
+                    topic_pattern = job['product_list']['product_list']['publish_topic']
+                    topics = []
+                    # Create filenames and topics
+                    for fmat, fmat_config in plist_iter(job['product_list']['product_list'],
+                                                        job['input_mda'].copy()):
+                        fname_pattern = fmat['fname_pattern']
+                        filename = compose(os.path.join(fmat['output_dir'],
+                                                        fname_pattern), fmat)
+                        fmat.pop('format', None)
+                        fmat_config['filename'] = filename
+                        topics.append(compose(topic_pattern, fmat))
 
             pub(job)
             message.assert_called()
@@ -1362,64 +1366,81 @@ class TestFilePublisher(TestCase):
         from trollflow2.plugins import FilePublisher
 
         # Direct instantiation
-        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb_:
-            pub = FilePublisher()
-            pub.pub.start.assert_called_once()
-            assert mock.call('l2processor', port=0, nameservers=None) in nb_.mock_calls
-            assert pub.port == 0
-            assert pub.nameservers is None
-            pub = FilePublisher(port=40000, nameservers=['localhost'])
-            assert mock.call('l2processor', port=40000,
-                             nameservers=['localhost']) in nb_.mock_calls
-            assert pub.port == 40000
-            assert pub.nameservers == ['localhost']
-            assert len(pub.pub.start.mock_calls) == 2
+        with mock.patch('trollflow2.plugins.Message'):
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                    pub = FilePublisher()
+                    pub.pub.start.assert_called_once()
+                    assert mock.call('l2processor', port=0, nameservers="") in NoisyPublisher.mock_calls
+                    Publisher.assert_not_called()
+                    assert pub.port == 0
+                    assert pub.nameservers == ""
+                    pub = FilePublisher(port=40000, nameservers=['localhost'])
+                    assert mock.call('l2processor', port=40000,
+                                     nameservers=['localhost']) in NoisyPublisher.mock_calls
+                    assert pub.port == 40000
+                    assert pub.nameservers == ['localhost']
+                    assert len(pub.pub.start.mock_calls) == 2
+
+        # Direct instantiation with nameservers set to None, which should use Publisher instead of NoisyPublisher
+        with mock.patch('trollflow2.plugins.Message'):
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                    pub = FilePublisher(port=40000, nameservers=None)
+                    NoisyPublisher.assert_not_called()
+                    Publisher.assert_called_once_with('tcp://*:40000', 'l2processor')
 
         # Instantiate via loading YAML
-        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb_:
-
-            fpub = yaml.load(YAML_FILE_PUBLISHER, Loader=yaml.UnsafeLoader)
-            assert mock.call('l2processor', port=40002,
-                             nameservers=['localhost']) in nb_.mock_calls
-            fpub.pub.start.assert_called_once()
-            assert fpub.port == 40002
-            assert fpub.nameservers == ['localhost']
+        with mock.patch('trollflow2.plugins.Message'):
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                    fpub = yaml.load(YAML_FILE_PUBLISHER, Loader=yaml.UnsafeLoader)
+                    assert mock.call('l2processor', port=40002,
+                                     nameservers=['localhost']) in NoisyPublisher.mock_calls
+                    Publisher.assert_not_called()
+                    fpub.pub.start.assert_called_once()
+                    assert fpub.port == 40002
+                    assert fpub.nameservers == ['localhost']
 
     def test_dispatch(self):
         """Test dispatch order messages."""
         from trollflow2.plugins import FilePublisher
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher'):
-            pub = FilePublisher()
-            job = {'product_list': self.product_list,
-                   'input_mda': self.input_mda}
-            pub(job)
-            dispatches = 0
-            for args, _kwargs in message.call_args_list:
-                mda = args[2]
-                if args[1] == 'file':
-                    self.assertIn('uri', mda)
-                    self.assertIn('uid', mda)
-                elif args[1] == 'dispatch':
-                    self.assertIn('source', mda)
-                    self.assertIn('target', mda)
-                    self.assertIn('file_mda', mda)
-                    self.assertEqual(mda['source'],
-                                     '/tmp/satdmz/pps/www/latest_2018/NOAA-15_20190217_0600_euron1_in_fname_ctth_static.png')  # noqa
-                    self.assertEqual(mda['target'],
-                                     'ftp://ftp.important_client.com/somewhere/NOAA-15_20190217_0600_euron1_in_fname_ctth_static.png')  # noqa
-                    dispatches += 1
-            self.assertEqual(dispatches, 1)
+        with mock.patch('trollflow2.plugins.Message') as message:
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                    pub = FilePublisher()
+                    job = {'product_list': self.product_list,
+                        'input_mda': self.input_mda}
+                    pub(job)
+                    dispatches = 0
+                    for args, _kwargs in message.call_args_list:
+                        mda = args[2]
+                        if args[1] == 'file':
+                            self.assertIn('uri', mda)
+                            self.assertIn('uid', mda)
+                        elif args[1] == 'dispatch':
+                            self.assertIn('source', mda)
+                            self.assertIn('target', mda)
+                            self.assertIn('file_mda', mda)
+                            self.assertEqual(mda['source'],
+                                            '/tmp/satdmz/pps/www/latest_2018/NOAA-15_20190217_0600_euron1_in_fname_ctth_static.png')  # noqa
+                            self.assertEqual(mda['target'],
+                                            'ftp://ftp.important_client.com/somewhere/NOAA-15_20190217_0600_euron1_in_fname_ctth_static.png')  # noqa
+                            dispatches += 1
+                    self.assertEqual(dispatches, 1)
 
     def test_deleting(self):
         """Test deleting the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
-            nb.return_value = nb_
-            pub = FilePublisher()
-            job = {'product_list': self.product_list,
-                   'input_mda': self.input_mda}
-            pub(job)
+        with mock.patch('trollflow2.plugins.Message') as message:
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                    NoisyPublisher.return_value = nb_
+                    pub = FilePublisher()
+                    job = {'product_list': self.product_list,
+                        'input_mda': self.input_mda}
+                    pub(job)
 
         nb_.stop.assert_not_called()
         del pub
@@ -1429,12 +1450,14 @@ class TestFilePublisher(TestCase):
         """Test stopping the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch('trollflow2.plugins.Message'), mock.patch('trollflow2.plugins.NoisyPublisher') as nb:
-            nb.return_value = nb_
-            pub = FilePublisher()
-            job = {'product_list': self.product_list,
-                   'input_mda': self.input_mda}
-            pub(job)
+        with mock.patch('trollflow2.plugins.Message') as message:
+            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                    NoisyPublisher.return_value = nb_
+                    pub = FilePublisher()
+                    job = {'product_list': self.product_list,
+                        'input_mda': self.input_mda}
+                    pub(job)
 
         nb_.stop.assert_not_called()
         pub.stop()

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1286,14 +1286,14 @@ class TestFilePublisher(TestCase):
         from trollsift import compose
         import os.path
         with mock.patch('trollflow2.plugins.Message') as message:
-            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+            with mock.patch('trollflow2.plugins.NoisyPublisher'):
                 with mock.patch('trollflow2.plugins.Publisher'):
                     pub = FilePublisher()
                     pub.pub.start.assert_called_once()
                     product_list = self.product_list.copy()
                     product_list['product_list']['publish_topic'] = '/{areaname}/{productname}'
                     job = {'product_list': product_list,
-                        'input_mda': self.input_mda}
+                           'input_mda': self.input_mda}
                     topic_pattern = job['product_list']['product_list']['publish_topic']
                     topics = []
                     # Create filenames and topics
@@ -1327,14 +1327,14 @@ class TestFilePublisher(TestCase):
         from trollsift import compose
         import os.path
         with mock.patch('trollflow2.plugins.Message') as message:
-            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
+            with mock.patch('trollflow2.plugins.NoisyPublisher'):
                 with mock.patch('trollflow2.plugins.Publisher'):
                     pub = FilePublisher()
                     pub.pub.start.assert_called_once()
                     product_list = self.product_list.copy()
                     product_list['product_list']['publish_topic'] = '/static_topic'
                     job = {'product_list': product_list,
-                        'input_mda': self.input_mda}
+                           'input_mda': self.input_mda}
                     topic_pattern = job['product_list']['product_list']['publish_topic']
                     topics = []
                     # Create filenames and topics
@@ -1406,11 +1406,11 @@ class TestFilePublisher(TestCase):
         """Test dispatch order messages."""
         from trollflow2.plugins import FilePublisher
         with mock.patch('trollflow2.plugins.Message') as message:
-            with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
-                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+            with mock.patch('trollflow2.plugins.NoisyPublisher'):
+                with mock.patch('trollflow2.plugins.Publisher'):
                     pub = FilePublisher()
                     job = {'product_list': self.product_list,
-                        'input_mda': self.input_mda}
+                           'input_mda': self.input_mda}
                     pub(job)
                     dispatches = 0
                     for args, _kwargs in message.call_args_list:
@@ -1433,13 +1433,13 @@ class TestFilePublisher(TestCase):
         """Test deleting the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch('trollflow2.plugins.Message') as message:
+        with mock.patch('trollflow2.plugins.Message'):
             with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
-                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                with mock.patch('trollflow2.plugins.Publisher'):
                     NoisyPublisher.return_value = nb_
                     pub = FilePublisher()
                     job = {'product_list': self.product_list,
-                        'input_mda': self.input_mda}
+                           'input_mda': self.input_mda}
                     pub(job)
 
         nb_.stop.assert_not_called()
@@ -1450,13 +1450,13 @@ class TestFilePublisher(TestCase):
         """Test stopping the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch('trollflow2.plugins.Message') as message:
+        with mock.patch('trollflow2.plugins.Message'):
             with mock.patch('trollflow2.plugins.NoisyPublisher') as NoisyPublisher:
-                with mock.patch('trollflow2.plugins.Publisher') as Publisher:
+                with mock.patch('trollflow2.plugins.Publisher'):
                     NoisyPublisher.return_value = nb_
                     pub = FilePublisher()
                     job = {'product_list': self.product_list,
-                        'input_mda': self.input_mda}
+                           'input_mda': self.input_mda}
                     pub(job)
 
         nb_.stop.assert_not_called()


### PR DESCRIPTION
This is part of my slowly ongoing plan on using Trollflow2 in a container on operations. For our (FMI) use case it might be necessary to use direct port connections between different parts of the whole chain (Trollmoves Server -> Trollmoves Client -> segment gatherer -> Trollflow2 -> Georest -> Geoserver) without any of the steps using Posttroll `nameservers`s.

The default (below) usage will still require a Posttroll `nameserver`, and the publisher will default to use the one on `localhost'. By default the publish port is automatically selected
```yaml
workers:
  - fun: !!python/object:trollflow2.plugins.FilePublisher {}
```

To use direct port communications without connecting to a `nameserver`:
```yaml
workers:
  - fun: !!python/object:trollflow2.plugins.FilePublisher {port=40000, nameserver: null}
```

As with the default use, the messages will be published on the localhost in a port either given by the user or selected automatically by Posttroll, but with the feature added here the `nameserver` will not be needed if the port is known.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
