### PR TITLE
For unstable build, also install pyresample.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,8 @@ jobs:
         run: |
           python -m pip install \
           --no-deps --upgrade \
-          git+https://github.com/pytroll/satpy;
+          git+https://github.com/pytroll/satpy \
+          git+https://github.com/pytroll/pyresample;
 
       - name: Install trollflow2
         run: |


### PR DESCRIPTION
For the unstable build in which satpy is installed without dependencies,
also install pyresample, or importing satpy may fail under some
circumstances.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->

