### PR TITLE
Skip products when data contain too many fill values

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -675,3 +675,7 @@ def _get_plugin_conf(product_list, path, defaults):
         conf[key] = get_config_value(product_list, path, key,
                                      default=defaults.get(key))
     return conf
+
+
+def check_valid(job):
+    raise NotImplementedError()

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1516,5 +1516,28 @@ class TestFilePublisher(TestCase):
         nb_.stop.assert_called_once()
 
 
+def test_valid_filter():
+    """Test filter for minimum fraction of valid data."""
+    from trollflow2.launcher import yaml, UnsafeLoader
+    from trollflow2.plugins import check_valid
+    product_list = yaml.load(yaml_test3, Loader=UnsafeLoader)
+    scene = mock.MagicMock()
+    resampled_scene = mock.MagicMock()
+    job = {}
+    job['scene'] = scene
+    job['product_list'] = product_list.copy()
+    job['input_mda'] = input_mda.copy()
+    job['resampled_scenes'] = {"euron1": resampled_scene}
+    prods = job['product_list']['product_list']['areas']['euron1']['products']
+    prods['green_snow']["min_valid"] = 10
+    for p in ("IR016", "IR037", "overview"):
+        prods[p] = {"min_valid": 10}
+    check_valid(job)
+    assert "green_snow" not in resampled_scene
+    assert "IR016" not in resampled_scene
+    assert "IR037" in resampled_scene
+    assert "overview" in resampled_scene
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Plugin to check validity of channel data before continuing processing.  This will help us when AVHRR switches 3A/3B so we don't generate empty channels and products.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #111 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
