### PR TITLE
Add no. of files to check_results log message

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -92,6 +92,7 @@ def check_results(produced_files, start_time, exitcode):
     """Make sure the composites have been saved."""
     end_time = datetime.now()
     error_detected = False
+    qsize = produced_files.qsize()
     while True:
         try:
             saved_file = produced_files.get(block=False)
@@ -112,7 +113,8 @@ def check_results(produced_files, start_time, exitcode):
             LOG.critical('Process crashed with exit code %d', exitcode)
     if not error_detected:
         elapsed = end_time - start_time
-        LOG.info('All files produced nominally in %s.', str(elapsed), extra={'time': elapsed})
+        LOG.info(f'All {qsize:d} files produced nominally in '
+                 f"{elapsed!s}")
 
 
 def run(prod_list, topics=None, test_message=None, nameserver='localhost',

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -26,6 +26,9 @@ import sys
 import time
 import pytest
 import unittest
+import datetime
+import logging
+import queue
 
 import yaml
 
@@ -443,6 +446,57 @@ class TestDistributed(TestCase):
         res = get_dask_client(config)
         assert res is None
         assert ncores.call_count == 3
+
+
+def test_check_results(tmp_path, caplog):
+    """Test functionality for check_results."""
+    from trollflow2.launcher import check_results
+
+    class FakeQueue:
+        def __init__(self, lo, hi, skip=[]):
+            self._files = set()
+            for i in range(lo, hi):
+                f = (tmp_path / f"file{i:d}")
+                self._files.add(str(f))
+                if i not in skip:
+                    with f.open(mode="wt") as fp:
+                        fp.write("zucchini" * i)
+
+        def get(self, block=None):
+            try:
+                return self._files.pop()
+            except KeyError:
+                raise queue.Empty
+
+        def qsize(self):
+            return len(self._files)
+
+    produced_files = FakeQueue(0, 3)
+    start_time = datetime.datetime(1900, 1, 1)
+    exitcode = 0
+    with caplog.at_level(logging.DEBUG):
+        check_results(produced_files, start_time, exitcode)
+    assert "Empty file detected" in caplog.text
+    assert "files produced nominally" not in caplog.text
+
+    produced_files = FakeQueue(5, 8, skip=[6])
+    with caplog.at_level(logging.DEBUG):
+        check_results(produced_files, start_time, exitcode)
+    assert "Missing file" in caplog.text
+    assert "files produced nominally" not in caplog.text
+
+    produced_files = FakeQueue(10, 13)
+    with caplog.at_level(logging.DEBUG):
+        check_results(produced_files, start_time, exitcode)
+    assert "All 3 files produced nominally in 44312 days" in caplog.text  # never mind tomorrow
+
+    with caplog.at_level(logging.DEBUG):
+        check_results(produced_files, start_time, 1)
+    assert "Process crashed with exit code 1" in caplog.text
+
+    with caplog.at_level(logging.DEBUG):
+        check_results(produced_files, start_time, -1)
+    assert "Process killed with signal 1" in caplog.text
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When check_results logs that all files have been produced successfully,
tell the user how many files those are.

Add unit test for check_results.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #113 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
