### PR TITLE
Use queued logging for running in subprocesses

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -58,7 +58,6 @@ def main():
     """Launch trollflow2."""
     args = vars(parse_args())
 
-
     log_config = args.pop("log_config", None)
     if log_config is not None:
         with open(log_config) as fd:

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -56,15 +56,18 @@ def parse_args():
 
 def main():
     """Launch trollflow2."""
-    args = parse_args()
-    prod_list = args.product_list
-    test_message = args.test_message
-    topics = args.topic
-    nameserver = args.nameserver
-    addresses = args.addresses
+    args = vars(parse_args())
+    print(args)
 
-    if args.log_config is not None:
-        with open(args.log_config) as fd:
+    # prod_list = args.product_list
+    # test_message = args.test_message
+    # topics = args.topic
+    # nameserver = args.nameserver
+    # addresses = args.addresses
+
+    log_config = args.pop("log_config", None)
+    if log_config is not None:
+        with open(log_config) as fd:
             import yaml
             log_dict = yaml.load(fd.read())
             logging.config.dictConfig(log_dict)
@@ -72,8 +75,11 @@ def main():
         from satpy.utils import debug_on
         debug_on()
 
-    run(prod_list, topics=topics, test_message=test_message,
-        nameserver=nameserver, addresses=addresses)
+    product_list = args.pop("product_list")
+    test_message = args.pop("test_message")
+    connection_parameters = args
+
+    run(product_list, connection_parameters, test_message)
 
 
 if __name__ == "__main__":

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -57,7 +57,6 @@ def parse_args():
 def main():
     """Launch trollflow2."""
     args = vars(parse_args())
-    print(args)
 
     # prod_list = args.product_list
     # test_message = args.test_message

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -58,11 +58,6 @@ def main():
     """Launch trollflow2."""
     args = vars(parse_args())
 
-    # prod_list = args.product_list
-    # test_message = args.test_message
-    # topics = args.topic
-    # nameserver = args.nameserver
-    # addresses = args.addresses
 
     log_config = args.pop("log_config", None)
     if log_config is not None:

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -145,8 +145,9 @@ def run(product_list, connection_parameters=None, test_message=None):
     """Spawn one or multiple subprocesses to run the jobs from the product list."""
     test_message = get_test_message(test_message)
     if test_message:
-        return _run_threaded(product_list, test_message)
-    return _run_subprocess(product_list, connection_parameters)
+        _run_threaded(product_list, test_message)
+    else:
+        _run_subprocess(product_list, connection_parameters)
 
 
 def _run_threaded(product_list, test_message):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -93,7 +93,10 @@ def check_results(produced_files, start_time, exitcode):
     """Make sure the composites have been saved."""
     end_time = datetime.now()
     error_detected = False
-    qsize = produced_files.qsize()
+    try:
+        qsize = produced_files.qsize()
+    except NotImplementedError:  # MacOS
+        qsize = None
     while True:
         try:
             saved_file = produced_files.get(block=False)
@@ -114,8 +117,12 @@ def check_results(produced_files, start_time, exitcode):
             LOG.critical('Process crashed with exit code %d', exitcode)
     if not error_detected:
         elapsed = end_time - start_time
-        LOG.info(f'All {qsize:d} files produced nominally in '
-                 f"{elapsed!s}", extra={"time": elapsed})
+        if qsize is not None:
+            LOG.info(f'All {qsize:d} files produced nominally in '
+                     f"{elapsed!s}", extra={"time": elapsed})
+        else:
+            LOG.info(f'All files produced nominally in '
+                     f"{elapsed!s}", extra={"time": elapsed})
 
 
 def generate_messages(connection_parameters):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -306,7 +306,7 @@ def get_dask_client(config):
     return client
 
 
-def qlogged_process(msg, prod_list, produced_files, log_queue):
+def queue_logged_process(msg, prod_list, produced_files, log_queue):
     """Run `process` with a queued log."""
     _reset_log_handlers()
     handler = handlers.QueueHandler(log_queue)

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -165,7 +165,7 @@ def _run_subprocess(product_list, connection_parameters=None):
     LOG.info("Launching trollflow2 with subprocesses")
     from multiprocessing import Process
     log_queue = Queue()
-    target_fun = partial(qlogged_process, log_queue=log_queue, prod_list=product_list)
+    target_fun = partial(queue_logged_process, log_queue=log_queue, prod_list=product_list)
     connection_parameters = _fill_in_connection_parameters(connection_parameters, product_list)
 
     messages = generate_messages(connection_parameters)

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -30,21 +30,19 @@ memory buildup.
 import ast
 import copy
 import gc
-import logging.handlers
 import os
 import re
-import traceback
 import signal
+import traceback
 from collections import OrderedDict
 from datetime import datetime
-from logging import getLogger, handlers
 from functools import partial
+from logging import getLogger, handlers
 from multiprocessing import Queue
+from queue import Empty
 
 import yaml
-from queue import Empty
 from six.moves.urllib.parse import urlparse
-
 from trollflow2.dict_tools import gen_dict_extract, plist_iter
 from trollflow2.plugins import AbortProcessing
 
@@ -171,7 +169,7 @@ def _run_subprocess(product_list, connection_parameters=None):
 
     messages = generate_messages(connection_parameters)
 
-    qlog_listener = logging.handlers.QueueListener(log_queue, *LOG.handlers)
+    qlog_listener = handlers.QueueListener(log_queue, *LOG.handlers)
     qlog_listener.start()
     try:
         _run_product_list_on_messages(messages, target_fun, Process)

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -156,7 +156,7 @@ def _run_threaded(product_list, test_message):
     from posttroll.message import Message
     messages = [Message(rawstr=test_message)]
     target_fun = partial(process, prod_list=product_list)
-    return _run_product_list_on_messages(messages, target_fun, Thread)
+    _run_product_list_on_messages(messages, target_fun, Thread)
 
 
 def _run_subprocess(product_list, connection_parameters=None):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -260,7 +260,7 @@ class TestRun(TestCase):
                 run(prod_list)
             except KeyboardInterrupt:
                 pass
-            assert process.call_count == 0
+            process.assert_not_called()
 
     def test_run_uses_process_via_multiprocessing(self):
         """Test that process is called through Process."""

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -252,6 +252,7 @@ class TestRun(TestCase):
                 mock.patch('trollflow2.launcher.open'),\
                 mock.patch('trollflow2.launcher.generate_messages') as generate_messages,\
                 mock.patch('trollflow2.launcher.process') as process,\
+                mock.patch('trollflow2.launcher.check_results'),\
                 mock.patch('multiprocessing.Process'):
             generate_messages.side_effect = ['foo', KeyboardInterrupt]
             prod_list = 'bar'

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -395,7 +395,7 @@ class TestRunLogging(TestCase):
                 run(0)
             finally:
                 LOG.removeHandler(fake_handler)
-            assert len(fake_handler.method_calls) > 0
+            assert fake_handler.method_calls
 
     def test_target_fun_does_not_log_to_existing_handlers_directly(self):
         """Test that target_fun does not log to existing handlers directly."""

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -245,15 +245,47 @@ class TestRun(TestCase):
         super().setUp()
         self.config = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
-    def test_run(self):
-        """Test running."""
+    def test_run_does_not_call_process_directly(self):
+        """Test that process is called through Process."""
+        from trollflow2.launcher import run
+        with mock.patch('trollflow2.launcher.yaml.load'),\
+                mock.patch('trollflow2.launcher.open'),\
+                mock.patch('trollflow2.launcher.generate_messages') as generate_messages,\
+                mock.patch('trollflow2.launcher.process') as process,\
+                mock.patch('multiprocessing.Process'):
+            generate_messages.side_effect = ['foo', KeyboardInterrupt]
+            prod_list = 'bar'
+            try:
+                run(prod_list)
+            except KeyboardInterrupt:
+                pass
+            assert process.call_count == 0
+
+    def test_run_uses_process_via_multiprocessing(self):
+        """Test that process is called through Process."""
+        from trollflow2.launcher import run
+        from threading import Thread
+        with mock.patch('trollflow2.launcher.yaml.load'),\
+                mock.patch('trollflow2.launcher.open'),\
+                mock.patch('trollflow2.launcher.generate_messages') as generate_messages,\
+                mock.patch('trollflow2.launcher.process') as process,\
+                mock.patch('multiprocessing.Process') as Process:
+            generate_messages.side_effect = ['foo', KeyboardInterrupt]
+            Process.side_effect = Thread
+            prod_list = 'bar'
+            try:
+                run(prod_list)
+            except KeyboardInterrupt:
+                pass
+            assert process.called
+
+    def test_run_relies_on_listener(self):
+        """Test running relies on listener."""
         from trollflow2.launcher import run
         with mock.patch('trollflow2.launcher.yaml.load') as yaml_load,\
                 mock.patch('trollflow2.launcher.open'),\
-                mock.patch('trollflow2.launcher.process') as process,\
                 mock.patch('multiprocessing.Process') as Process,\
-                mock.patch('trollflow2.launcher.ListenerContainer') as lc_,\
-                mock.patch('multiprocessing.Queue') as queue:
+                mock.patch('trollflow2.launcher.ListenerContainer') as lc_:
             listener = mock.MagicMock()
             listener.output_queue.get.return_value = 'foo'
             lc_.return_value = listener
@@ -262,17 +294,12 @@ class TestRun(TestCase):
             # stop looping
             proc_ret.join.side_effect = KeyboardInterrupt
             yaml_load.return_value = self.config
-            the_queue = mock.MagicMock()
-            queue.return_value = the_queue
             prod_list = 'bar'
             try:
                 run(prod_list)
             except KeyboardInterrupt:
                 pass
             listener.output_queue.called_once()
-            Process.assert_called_with(args=('foo', prod_list, the_queue), target=process)
-            proc_ret.start.assert_called_once()
-            proc_ret.join.assert_called_once()
             lc_.assert_called_with(addresses=None, nameserver='localhost',
                                    topics=['/topic1', '/topic2'])
             # Subscriber topics are removed from config
@@ -280,11 +307,43 @@ class TestRun(TestCase):
             # Topics are given as command line option
             lc_.reset_mock()
             try:
-                run(prod_list, topics=['/topic3'])
+                run(prod_list, connection_parameters=dict(topic=['/topic3']))
             except KeyboardInterrupt:
                 pass
             lc_.assert_called_with(addresses=None, nameserver='localhost',
                                    topics=['/topic3'])
+
+    def test_run_starts_and_joins_process(self):
+        """Test running."""
+        from trollflow2.launcher import run
+        with mock.patch('trollflow2.launcher.yaml.load') as yaml_load,\
+                mock.patch('trollflow2.launcher.open'),\
+                mock.patch('multiprocessing.Process') as Process,\
+                mock.patch('trollflow2.launcher.ListenerContainer') as lc_:
+            listener = mock.MagicMock()
+            listener.output_queue.get.return_value = 'foo'
+            lc_.return_value = listener
+            proc_ret = mock.MagicMock()
+            Process.return_value = proc_ret
+            # stop looping
+            proc_ret.join.side_effect = KeyboardInterrupt
+            yaml_load.return_value = self.config
+            prod_list = 'bar'
+            try:
+                run(prod_list)
+            except KeyboardInterrupt:
+                pass
+            proc_ret.start.assert_called_once()
+            proc_ret.join.assert_called_once()
+
+
+class TestInterruptRun(TestCase):
+    """Test case for running the plugins."""
+
+    def setUp(self):
+        """Set up the test case."""
+        super().setUp()
+        self.config = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
     def test_run_keyboard_interrupt(self):
         """Test interrupting the run with a ctrl-C."""
@@ -299,6 +358,74 @@ class TestRun(TestCase):
             lc_.return_value = listener
             run(0)
             listener.stop.assert_called_once()
+
+
+class TestRunLogging(TestCase):
+    """Test case for checking the logging in `run`."""
+
+    def setUp(self):
+        """Set up the test case."""
+        super().setUp()
+        self.config = yaml.load(yaml_test1, Loader=UnsafeLoader)
+
+    def test_target_fun_logs_to_existing_handlers(self):
+        """Test that target_fun logs to existing handlers."""
+        from trollflow2.launcher import run
+        from trollflow2.launcher import LOG
+        from threading import Thread
+        with mock.patch('trollflow2.launcher.yaml.load'),\
+                mock.patch('trollflow2.launcher.open'), \
+                mock.patch('trollflow2.launcher.process') as process,\
+                mock.patch('trollflow2.launcher.generate_messages') as generate_messages, \
+                mock.patch('trollflow2.launcher.check_results'), \
+                mock.patch('multiprocessing.Process') as Process:
+
+            def fake_process(*args, **kwargs):
+                LOG.error('hej')
+
+            fake_handler = mock.MagicMock()
+            fake_handler.level = 0
+            Process.side_effect = Thread
+            process.side_effect = fake_process
+            generate_messages.return_value = ['bla']
+
+            try:
+                LOG.addHandler(fake_handler)
+                run(0)
+            finally:
+                LOG.removeHandler(fake_handler)
+            assert len(fake_handler.method_calls) > 0
+
+    def test_target_fun_does_not_log_to_existing_handlers_directly(self):
+        """Test that target_fun does not log to existing handlers directly."""
+        from trollflow2.launcher import run
+        from trollflow2.launcher import LOG
+        from threading import Thread
+        with mock.patch('trollflow2.launcher.yaml.load'),\
+                mock.patch('trollflow2.launcher.open'), \
+                mock.patch('trollflow2.launcher.process') as process,\
+                mock.patch('trollflow2.launcher.generate_messages') as generate_messages, \
+                mock.patch('trollflow2.launcher.check_results'), \
+                mock.patch('multiprocessing.Process') as Process:
+
+            def fake_process(*args, **kwargs):
+                LOG.error('hej')
+
+            fake_handler = mock.MagicMock()
+            fake_handler.level = 0
+            Process.side_effect = Thread
+            process.side_effect = fake_process
+            generate_messages.return_value = ['bla']
+
+            try:
+                LOG.addHandler(fake_handler)
+                original_handlers = set(LOG.handlers.copy())
+                run(0)
+                assert len(LOG.handlers) >= 1
+                new_handlers = set(LOG.handlers.copy())
+                assert len(new_handlers & original_handlers) == 0
+            finally:
+                LOG.removeHandler(fake_handler)
 
 
 class TestExpand(TestCase):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -271,14 +271,18 @@ class TestRun(TestCase):
                 mock.patch('trollflow2.launcher.generate_messages') as generate_messages,\
                 mock.patch('trollflow2.launcher.process') as process,\
                 mock.patch('multiprocessing.Process') as Process:
-            generate_messages.side_effect = ['foo', KeyboardInterrupt]
+            def gen_messages(*args):
+                del args
+                yield 'foo'
+                raise KeyboardInterrupt
+            generate_messages.side_effect = gen_messages
             Process.side_effect = Thread
             prod_list = 'bar'
             try:
                 run(prod_list)
             except KeyboardInterrupt:
                 pass
-            assert process.called
+            process.assert_called_once()
 
     def test_run_relies_on_listener(self):
         """Test running relies on listener."""


### PR DESCRIPTION
This PR fixes the log passing from subprocesses to the main process by using a QueueHandler instead of using the predifined handlers passed on through the forking mechanism. This is the recommended way of doing the logging across processes.
The current implementation is suspected to be at the origin of deadlocks causing trollflow2 processing to stop and hang forever, as observed by @gerritholl and myself.

The runner code and tests were also refactored for cleaning purposes.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
