### PR TITLE
Add debug log message on dask scheduler used

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -311,6 +311,8 @@ def get_dask_client(config):
     except KeyError:
         LOG.debug("Distributed processing not configured, "
                   "using default scheduler")
+    else:
+        LOG.debug(f"Using dask distributed client {client!s}")
 
     return client
 


### PR DESCRIPTION
Add a log message with level DEBUG when the configure dask scheduler is used
successfully.  Expand unit test to confirm that this and other
messages are logged when expected.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
