### PR TITLE
Fix MacOS timeout test skip

### DIFF
--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -22,14 +22,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 """Test the launcher module."""
 
-import sys
-import time
-import pytest
-import unittest
 import datetime
 import logging
 import queue
+import sys
+import time
+import unittest
 
+import pytest
 import yaml
 from yaml import YAMLError
 


### PR DESCRIPTION
This PR refactors the test_process method to allow skipping the timeout test properly on MacOS

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->

cc @gerritholl 