### PR TITLE
Use safe loading for logging config

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -62,7 +62,7 @@ def main():
     if log_config is not None:
         with open(log_config) as fd:
             import yaml
-            log_dict = yaml.load(fd.read())
+            log_dict = yaml.safe_load(fd.read())
             logging.config.dictConfig(log_dict)
     else:
         from satpy.utils import debug_on


### PR DESCRIPTION
Pyyaml 6.0 removed the plain `yaml.load()` call and now requires the user to define a `Loader` kwarg. This PR switches to `yaml.safe_load()` when reading the logging config, where a loader wasn't defined.

 - [x] Closes #121  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
