### PR TITLE
Logging fix using global QueueHandler

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -25,7 +25,6 @@
 import argparse
 import logging
 
-from trollflow2.launcher import run, LOG_QUEUE
 from trollflow2.logging import logging_on
 
 
@@ -57,6 +56,7 @@ def parse_args():
 
 def main():
     """Launch trollflow2."""
+    from trollflow2.launcher import run, LOG_QUEUE
     args = vars(parse_args())
 
     log_config = args.pop("log_config", None)

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -25,7 +25,7 @@
 import argparse
 import logging
 
-from trollflow2.launcher import run
+from trollflow2.launcher import run, LOG_QUEUE
 from trollflow2.logging import logging_on
 
 
@@ -67,8 +67,8 @@ def main():
 
     logger = logging.getLogger("satpy_launcher")
 
-    with logging_on(log_config):
-        logger.warning("oh no!")
+    with logging_on(LOG_QUEUE, log_config):
+        logger.warning("Launching Satpy-based runner.")
         product_list = args.pop("product_list")
         test_message = args.pop("test_message")
         connection_parameters = args

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -41,8 +41,12 @@ def parse_args():
                         help="The yaml file with the product list",
                         type=str)
     parser.add_argument("-m", "--test_message",
-                        help="File path with the message used for testing offline",
+                        help="File path with the message used for testing offline. This implies threaded running.",
                         type=str, required=False)
+    parser.add_argument("-t", "--threaded",
+                        help="Run the product generation in threads instead of processes.",
+                        action='store_true')
+
     parser.add_argument("-c", "--log-config",
                         help="Log config file (yaml) to use",
                         type=str, required=False)
@@ -74,9 +78,10 @@ def main():
         logger.warning("Launching Satpy-based runner.")
         product_list = args.pop("product_list")
         test_message = args.pop("test_message")
+        threaded = args.pop("threaded")
         connection_parameters = args
 
-        runner = Runner(product_list, log_queue, connection_parameters, test_message)
+        runner = Runner(product_list, log_queue, connection_parameters, test_message, threaded)
         runner.run()
 
 

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -25,7 +25,7 @@
 import argparse
 
 from trollflow2.launcher import run
-import logging
+from trollflow2.logging import logging_on
 
 
 def parse_args():
@@ -62,17 +62,14 @@ def main():
     if log_config is not None:
         with open(log_config) as fd:
             import yaml
-            log_dict = yaml.safe_load(fd.read())
-            logging.config.dictConfig(log_dict)
-    else:
-        from satpy.utils import debug_on
-        debug_on()
+            log_config = yaml.safe_load(fd.read())
 
-    product_list = args.pop("product_list")
-    test_message = args.pop("test_message")
-    connection_parameters = args
+    with logging_on(log_config):
+        product_list = args.pop("product_list")
+        test_message = args.pop("test_message")
+        connection_parameters = args
 
-    run(product_list, connection_parameters, test_message)
+        run(product_list, connection_parameters, test_message)
 
 
 if __name__ == "__main__":

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -23,6 +23,7 @@
 """The satpy launcher."""
 
 import argparse
+import logging
 
 from trollflow2.launcher import run
 from trollflow2.logging import logging_on
@@ -64,7 +65,10 @@ def main():
             import yaml
             log_config = yaml.safe_load(fd.read())
 
+    logger = logging.getLogger("satpy_launcher")
+
     with logging_on(log_config):
+        logger.warning("oh no!")
         product_list = args.pop("product_list")
         test_message = args.pop("test_message")
         connection_parameters = args

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -26,6 +26,8 @@ import argparse
 import logging
 
 from trollflow2.logging import logging_on
+from trollflow2.launcher import Runner
+from multiprocessing import Manager
 
 
 def parse_args():
@@ -56,7 +58,6 @@ def parse_args():
 
 def main():
     """Launch trollflow2."""
-    from trollflow2.launcher import run, LOG_QUEUE
     args = vars(parse_args())
 
     log_config = args.pop("log_config", None)
@@ -67,13 +68,16 @@ def main():
 
     logger = logging.getLogger("satpy_launcher")
 
-    with logging_on(LOG_QUEUE, log_config):
+    log_queue = Manager().Queue()
+
+    with logging_on(log_queue, log_config):
         logger.warning("Launching Satpy-based runner.")
         product_list = args.pop("product_list")
         test_message = args.pop("test_message")
         connection_parameters = args
 
-        run(product_list, connection_parameters, test_message)
+        runner = Runner(product_list, log_queue, connection_parameters, test_message)
+        runner.run()
 
 
 if __name__ == "__main__":

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -39,7 +39,7 @@ from contextlib import suppress
 from datetime import datetime
 from functools import partial
 from logging import getLogger
-from multiprocessing import get_context, freeze_support
+from multiprocessing import get_context
 from queue import Empty
 from urllib.parse import urlparse
 
@@ -182,7 +182,6 @@ class Runner:
     def _run_subprocess(self):
         """Run in a subprocess, with queued logging."""
         LOG.info("Launching trollflow2 with subprocesses")
-        freeze_support()
         ctx = get_context("spawn")
         target_fun = partial(queue_logged_process, prod_list=self.product_list)
         self._fill_in_connection_parameters()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -181,8 +181,7 @@ class Runner:
     def _run_subprocess(self):
         """Run in a subprocess, with queued logging."""
         LOG.info("Launching trollflow2 with subprocesses")
-        from multiprocessing import get_context, freeze_support
-        freeze_support()
+        from multiprocessing import get_context
         ctx = get_context("spawn")
         target_fun = partial(queue_logged_process, prod_list=self.product_list)
         self._fill_in_connection_parameters()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -39,7 +39,6 @@ from contextlib import suppress
 from datetime import datetime
 from functools import partial
 from logging import getLogger
-from multiprocessing import get_context
 from queue import Empty
 from urllib.parse import urlparse
 
@@ -182,6 +181,8 @@ class Runner:
     def _run_subprocess(self):
         """Run in a subprocess, with queued logging."""
         LOG.info("Launching trollflow2 with subprocesses")
+        from multiprocessing import get_context, freeze_support
+        freeze_support()
         ctx = get_context("spawn")
         target_fun = partial(queue_logged_process, prod_list=self.product_list)
         self._fill_in_connection_parameters()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -325,7 +325,7 @@ def queue_logged_process(msg, prod_list, produced_files, log_queue):
     setup_queued_logging(log_queue)
     with suppress(ValueError):
         signal.signal(signal.SIGUSR1, print_traces)
-        LOG.debug("Use SIGUSR1 to check the current tracebacks of this subprocess.")
+        LOG.debug("Use SIGUSR1 on pid {} to check the current tracebacks of this subprocess.".format(os.getpid()))
     process(msg, prod_list, produced_files)
 
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -43,8 +43,7 @@ from multiprocessing import Manager
 from queue import Empty
 
 import yaml
-from six.moves.urllib.parse import urlparse
-
+from urllib.parse import urlparse
 from trollflow2.dict_tools import gen_dict_extract, plist_iter
 from trollflow2.logging import setup_queued_logging
 from trollflow2.plugins import AbortProcessing
@@ -64,7 +63,8 @@ except ImportError:
 LOG = getLogger(__name__)
 DEFAULT_PRIORITY = 999
 
-LOG_QUEUE = Manager().Queue()
+MANAGER = Manager()
+LOG_QUEUE = MANAGER.Queue()
 
 
 def tuple_constructor(loader, node):
@@ -200,7 +200,7 @@ def _fill_in_connection_parameters(connection_parameters, product_list):
 def _run_product_list_on_messages(messages, target_fun, process_class, log_queue=None):
     """Run the product list on the messages."""
     for msg in messages:
-        produced_files = Manager().Queue()
+        produced_files = MANAGER.Queue()
         kwargs = dict(produced_files=produced_files)
         if log_queue is not None:
             kwargs["log_queue"] = log_queue

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -341,9 +341,9 @@ def print_traces(signum, frame):
     import traceback
     print(f"Got signal {signum} in {frame}, dumping traces.", file=sys.stderr)
 
-    for thread, frame in sys._current_frames().items():
+    for thread, current_frame in sys._current_frames().items():
         print('Thread 0x%x' % thread, file=sys.stderr)
-        traceback.print_stack(frame, file=sys.stderr)
+        traceback.print_stack(current_frame, file=sys.stderr)
         print(file=sys.stderr)
 
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -39,6 +39,7 @@ from contextlib import suppress
 from datetime import datetime
 from functools import partial
 from logging import getLogger
+from multiprocessing import get_context, freeze_support
 from queue import Empty
 from urllib.parse import urlparse
 
@@ -181,7 +182,7 @@ class Runner:
     def _run_subprocess(self):
         """Run in a subprocess, with queued logging."""
         LOG.info("Launching trollflow2 with subprocesses")
-        from multiprocessing import get_context
+        freeze_support()
         ctx = get_context("spawn")
         target_fun = partial(queue_logged_process, prod_list=self.product_list)
         self._fill_in_connection_parameters()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -39,7 +39,6 @@ from contextlib import suppress
 from datetime import datetime
 from functools import partial
 from logging import getLogger
-from logging.handlers import QueueHandler
 from multiprocessing import Manager
 from queue import Empty
 
@@ -47,6 +46,7 @@ import yaml
 from six.moves.urllib.parse import urlparse
 
 from trollflow2.dict_tools import gen_dict_extract, plist_iter
+from trollflow2.logging import setup_queued_logging
 from trollflow2.plugins import AbortProcessing
 
 try:
@@ -322,8 +322,7 @@ def get_dask_client(config):
 
 def queue_logged_process(msg, prod_list, produced_files, log_queue):
     """Run `process` with a queued log."""
-    root_logger = getLogger()
-    root_logger.addHandler(QueueHandler(log_queue))
+    setup_queued_logging(log_queue)
     with suppress(ValueError):
         signal.signal(signal.SIGUSR1, print_traces)
         LOG.debug("Use SIGUSR1 to check the current tracebacks of this subprocess.")

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -162,7 +162,7 @@ class Runner:
         self.threaded = threaded
 
     def run(self):
-        """Spawn one or multiple subprocesses to run the jobs from the product list."""
+        """Spawn one or multiple subprocesses or threads to run the jobs from the product list."""
         messages = self._get_message_iterator()
 
         if self.threaded:
@@ -339,12 +339,12 @@ def print_traces(signum, frame):
     """Print traces for debugging."""
     import sys
     import traceback
-    print(f"Got signal {signum} in {frame}, dumping traces.")
+    print(f"Got signal {signum} in {frame}, dumping traces.", file=sys.stderr)
 
     for thread, frame in sys._current_frames().items():
-        print('Thread 0x%x' % thread)
-        traceback.print_stack(frame)
-        print()
+        print('Thread 0x%x' % thread, file=sys.stderr)
+        traceback.print_stack(frame, file=sys.stderr)
+        print(file=sys.stderr)
 
 
 def process(msg, prod_list, produced_files):

--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -24,7 +24,8 @@
 import logging
 import logging.config
 from contextlib import contextmanager
-from logging.handlers import QueueListener
+from logging import getLogger, DEBUG
+from logging.handlers import QueueListener, QueueHandler
 
 DEFAULT_LOG_CONFIG = {'version': 1,
                       'disable_existing_loggers': False,
@@ -60,3 +61,10 @@ def logging_on(log_queue, config=None):
         yield
     finally:
         listener.stop()
+
+
+def setup_queued_logging(log_queue):
+    """Set up queued logging."""
+    root_logger = getLogger()
+    root_logger.addHandler(QueueHandler(log_queue))
+    root_logger.setLevel(DEBUG)

--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Pytroll developers
+#
+# Author(s):
+#
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+"""Logging utilities."""
+
+from contextlib import contextmanager
+import logging
+import logging.config
+from logging.handlers import QueueHandler, QueueListener
+from multiprocessing import Queue
+
+DEFAULT_LOG_CONFIG = {'version': 1,
+                      'formatters': {'pytroll': {'format': '[%(levelname)s: %(asctime)s : %(name)s] %(message)s',
+                                                 'datefmt': '%Y-%m-%d %H:%M:%S'}},
+                      'handlers': {'file': {'class': 'logging.StreamHandler',
+                                            'formatter': 'pytroll'}},
+                      'root': {'level': 'DEBUG', 'handlers': ['file']}}
+
+
+@contextmanager
+def logging_on(config=None):
+    """Activate queued logging.
+
+    This context activates logging through the use of logging's QueueHandler and
+    QueueListener.
+    Whether the default config parameters are used or a custom configuration is
+    passed, the regular handlers are removed from the root handler after
+    configuration and passed instead to the QueueListener instance, such that
+    the only handler exposed to the subprocesses or threads of trollflow2 is a
+    QueueHandler.
+    """
+    if config is None:
+        config = DEFAULT_LOG_CONFIG
+    else:
+        logging.config.dictConfig(config)
+
+    # set level
+    root = logging.getLogger()
+    if config is None:
+        handlers = []
+    else:
+        handlers = root.handlers.copy()
+        while root.hasHandlers():
+            root.removeHandler(root.handlers[0])
+
+    # set up queuehandler
+    que = Queue(-1)  # no limit on size
+    queue_handler = QueueHandler(que)
+
+    root.addHandler(queue_handler)
+
+    # set up default handler
+    if config is None:
+        console = logging.StreamHandler()
+        console.setFormatter(logging.Formatter("[%(levelname)s: %(asctime)s :"
+                                               " %(name)s] %(message)s",
+                                               '%Y-%m-%d %H:%M:%S'))
+        handlers.append(console)
+    # set up and run listener
+    listener = QueueListener(que, *handlers)
+    listener.start()
+    try:
+        yield
+    finally:
+        listener.stop()

--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -28,11 +28,12 @@ from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue
 
 DEFAULT_LOG_CONFIG = {'version': 1,
+                      'disable_existing_loggers': False,
                       'formatters': {'pytroll': {'format': '[%(levelname)s: %(asctime)s : %(name)s] %(message)s',
                                                  'datefmt': '%Y-%m-%d %H:%M:%S'}},
-                      'handlers': {'file': {'class': 'logging.StreamHandler',
-                                            'formatter': 'pytroll'}},
-                      'root': {'level': 'DEBUG', 'handlers': ['file']}}
+                      'handlers': {'console': {'class': 'logging.StreamHandler',
+                                               'formatter': 'pytroll'}},
+                      'root': {'level': 'DEBUG', 'handlers': ['console']}}
 
 
 @contextmanager
@@ -47,13 +48,13 @@ def logging_on(config=None):
     the only handler exposed to the subprocesses or threads of trollflow2 is a
     QueueHandler.
     """
+    root = logging.getLogger()
+
     if config is None:
         config = DEFAULT_LOG_CONFIG
     logging.config.dictConfig(config)
 
-    # set level
-    root = logging.getLogger()
-
+    # Lift out the existing handlers
     handlers = root.handlers.copy()
     while root.hasHandlers():
         root.removeHandler(root.handlers[0])

--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -49,17 +49,14 @@ def logging_on(config=None):
     """
     if config is None:
         config = DEFAULT_LOG_CONFIG
-    else:
-        logging.config.dictConfig(config)
+    logging.config.dictConfig(config)
 
     # set level
     root = logging.getLogger()
-    if config is None:
-        handlers = []
-    else:
-        handlers = root.handlers.copy()
-        while root.hasHandlers():
-            root.removeHandler(root.handlers[0])
+
+    handlers = root.handlers.copy()
+    while root.hasHandlers():
+        root.removeHandler(root.handlers[0])
 
     # set up queuehandler
     que = Queue(-1)  # no limit on size
@@ -67,13 +64,6 @@ def logging_on(config=None):
 
     root.addHandler(queue_handler)
 
-    # set up default handler
-    if config is None:
-        console = logging.StreamHandler()
-        console.setFormatter(logging.Formatter("[%(levelname)s: %(asctime)s :"
-                                               " %(name)s] %(message)s",
-                                               '%Y-%m-%d %H:%M:%S'))
-        handlers.append(console)
     # set up and run listener
     listener = QueueListener(que, *handlers)
     listener.start()

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -275,7 +275,7 @@ def product_missing_from_scene(product, scene):
     return False
 
 
-class FilePublisher(object):
+class FilePublisher:
     """Publisher for generated files."""
 
     def __init__(self, port=0, nameservers=""):
@@ -782,13 +782,13 @@ def _persist_what_we_must(job):
                 to_persist.append((scn, prod_name, scn[prod_name]))
     LOG.debug("Persisting early due to content checks")
     persisted = dask.persist(*[p[2] for p in to_persist])
-    for ((sc, prod_name, old), new) in zip(to_persist, persisted):
+    for ((sc, prod_name, _old), new) in zip(to_persist, persisted):
         sc[prod_name] = new
 
 
 def _product_meets_min_valid_data_fraction(
         prod_name, prod_props, area_name, area_props, job, exp_cov):
-    """Check if product meets min_valid_data_fraction
+    """Check if product meets min_valid_data_fraction.
 
     Helper for `check_valid_data_fraction`, check if ``product`` meets the
     ``min_valid_data_fraction`` as defined in ``prod_props``.
@@ -796,7 +796,6 @@ def _product_meets_min_valid_data_fraction(
     Returns True if product can remain or is absent.  Returns False if product
     has to be removed.
     """
-
     LOG.debug(f"Checking validity for {area_name:s}/{prod_name:s}")
     if prod_name not in job["resampled_scenes"][area_name]:
         LOG.debug(f"product {prod_name!s} not found, already removed or loading failed?")

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -387,6 +387,11 @@ class TestInterruptRun(TestCase):
 class TestRunLogging(TestCase):
     """Test case for checking the logging in `run`."""
 
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        """Inject the caplog fixture into this testcase instance."""
+        self._caplog = caplog
+
     def setUp(self):
         """Set up the test case."""
         super().setUp()

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -378,65 +378,6 @@ class TestRunLogging(TestCase):
         super().setUp()
         self.config = yaml.load(yaml_test1, Loader=UnsafeLoader)
 
-    def test_target_fun_logs_to_existing_handlers(self):
-        """Test that target_fun logs to existing handlers."""
-        from trollflow2.launcher import run
-        from trollflow2.launcher import LOG
-        from threading import Thread
-        with mock.patch('trollflow2.launcher.yaml.load'),\
-                mock.patch('trollflow2.launcher.open'), \
-                mock.patch('trollflow2.launcher.process') as process,\
-                mock.patch('trollflow2.launcher.generate_messages') as generate_messages, \
-                mock.patch('trollflow2.launcher.check_results'), \
-                mock.patch('multiprocessing.Process') as Process:
-
-            def fake_process(*args, **kwargs):
-                LOG.error('hej')
-
-            fake_handler = mock.MagicMock()
-            fake_handler.level = 0
-            Process.side_effect = Thread
-            process.side_effect = fake_process
-            generate_messages.return_value = ['bla']
-
-            try:
-                LOG.addHandler(fake_handler)
-                run(0)
-            finally:
-                LOG.removeHandler(fake_handler)
-            assert fake_handler.method_calls
-
-    def test_target_fun_does_not_log_to_existing_handlers_directly(self):
-        """Test that target_fun does not log to existing handlers directly."""
-        from trollflow2.launcher import run
-        from trollflow2.launcher import LOG
-        from threading import Thread
-        with mock.patch('trollflow2.launcher.yaml.load'),\
-                mock.patch('trollflow2.launcher.open'), \
-                mock.patch('trollflow2.launcher.process') as process,\
-                mock.patch('trollflow2.launcher.generate_messages') as generate_messages, \
-                mock.patch('trollflow2.launcher.check_results'), \
-                mock.patch('multiprocessing.Process') as Process:
-
-            def fake_process(*args, **kwargs):
-                LOG.error('hej')
-
-            fake_handler = mock.MagicMock()
-            fake_handler.level = 0
-            Process.side_effect = Thread
-            process.side_effect = fake_process
-            generate_messages.return_value = ['bla']
-
-            try:
-                LOG.addHandler(fake_handler)
-                original_handlers = set(LOG.handlers.copy())
-                run(0)
-                assert len(LOG.handlers) >= 1
-                new_handlers = set(LOG.handlers.copy())
-                assert len(new_handlers & original_handlers) == 0
-            finally:
-                LOG.removeHandler(fake_handler)
-
 
 class TestExpand(TestCase):
     """Test expanding the product list."""

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -400,11 +400,11 @@ class TestRunLogging(TestCase):
     def test_subprocess_uses_queued_logging(self):
         """Test that the subprocess logs are handled."""
         from trollflow2.launcher import run
-        with mock.patch('trollflow2.launcher.yaml.load'),\
-                mock.patch('trollflow2.launcher.open'),\
-                mock.patch('trollflow2.launcher.generate_messages') as generate_messages,\
-                mock.patch('trollflow2.launcher.process'),\
-                mock.patch('trollflow2.launcher.check_results'),\
+        with mock.patch('trollflow2.launcher.yaml.load'), \
+                mock.patch('trollflow2.launcher.open'), \
+                mock.patch('trollflow2.launcher.generate_messages') as generate_messages, \
+                mock.patch('trollflow2.launcher.process'), \
+                mock.patch('trollflow2.launcher.check_results'), \
                 mock.patch('multiprocessing.get_context'):
             generate_messages.side_effect = ['foo', KeyboardInterrupt]
             prod_list = 'bar'

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -22,8 +22,9 @@
 """Tests for the logging utilities."""
 
 import logging
+import sys
 import time
-from multiprocessing import Manager, get_context, freeze_support
+from multiprocessing import Manager, get_context
 from unittest import mock
 
 import pytest
@@ -91,13 +92,14 @@ def fun(q, log_message):
 
 def run_subprocess(log_message, queue):
     """Run a subprocess."""
-    freeze_support()
     ctx = get_context('spawn')
     proc = ctx.Process(target=fun, args=(queue, log_message))
     proc.start()
     proc.join()
 
 
+@pytest.mark.skipif(sys.platform != "linux",
+                    reason="Subprocess logging seems to work only on Linux")
 def test_logging_works_in_subprocess(caplog):
     """Test that the logs get out there, even from a subprocess."""
     log_message = 'yeah, we are in a subprocess now'

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -22,12 +22,12 @@
 """Tests for the logging utilities."""
 
 import logging
+import sys
 import time
 from multiprocessing import Manager
 from unittest import mock
 
 import pytest
-
 from trollflow2.logging import logging_on, setup_queued_logging
 
 log_queue = Manager().Queue(-1)  # no limit on size
@@ -92,14 +92,14 @@ def fun(q, log_message):
 
 def run_subprocess(log_message, queue):
     """Run a subprocess."""
-    from multiprocessing import get_context, freeze_support
-    freeze_support()
+    from multiprocessing import get_context
     ctx = get_context('spawn')
     proc = ctx.Process(target=fun, args=(queue, log_message))
     proc.start()
     proc.join()
 
-
+@pytest.mark.skipif(sys.platform != "linux",
+                    reason="Logging from a subprocess seems to work only on Linux")
 def test_logging_works_in_subprocess(caplog):
     """Test that the logs get out there, even from a subprocess."""
     log_message = 'yeah, we are in a subprocess now'

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -28,7 +28,7 @@ from unittest import mock
 
 import pytest
 
-from trollflow2.logging import logging_on
+from trollflow2.logging import logging_on, setup_queued_logging
 
 log_queue = Manager().Queue(-1)  # no limit on size
 
@@ -86,10 +86,8 @@ def test_logging_works(caplog):
 def fun(q, log_message):
     """Fake a function to run."""
     log = logging.getLogger('for fun')
-    from logging.handlers import QueueHandler
-    q_handler = QueueHandler(q)
-    logging.getLogger().addHandler(q_handler)
-    log.warning(log_message)
+    setup_queued_logging(q)
+    log.debug(log_message)
 
 
 def run_subprocess(log_message, queue):

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -22,12 +22,12 @@
 """Tests for the logging utilities."""
 
 import logging
-import sys
 import time
-from multiprocessing import Manager, get_context
+from multiprocessing import Manager
 from unittest import mock
 
 import pytest
+
 from trollflow2.logging import logging_on, setup_queued_logging
 
 log_queue = Manager().Queue(-1)  # no limit on size
@@ -92,14 +92,14 @@ def fun(q, log_message):
 
 def run_subprocess(log_message, queue):
     """Run a subprocess."""
+    from multiprocessing import get_context, freeze_support
+    freeze_support()
     ctx = get_context('spawn')
     proc = ctx.Process(target=fun, args=(queue, log_message))
     proc.start()
     proc.join()
 
 
-@pytest.mark.skipif(sys.platform != "linux",
-                    reason="Subprocess logging seems to work only on Linux")
 def test_logging_works_in_subprocess(caplog):
     """Test that the logs get out there, even from a subprocess."""
     log_message = 'yeah, we are in a subprocess now'

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -38,14 +38,12 @@ def teardown_function():
         root.removeHandler(root.handlers[0])
 
 
-def test_logging_adds_one_queue_handlers(caplog):
+def test_logging_adds_one_queue_handlers():
     """Test that logging adds a queue handler."""
     log = logging.getLogger()
     with logging_on():
-        log.warning('bla')
         assert len(log.handlers) == 1
         assert isinstance(log.handlers[0], QueueHandler)
-    assert "bla" in caplog.text
 
 
 def test_logging_is_queued_by_default():

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -23,11 +23,10 @@
 
 import logging
 import time
-from multiprocessing import Manager
+from multiprocessing import Manager, get_context, freeze_support
 from unittest import mock
 
 import pytest
-
 from trollflow2.logging import logging_on, setup_queued_logging
 
 log_queue = Manager().Queue(-1)  # no limit on size
@@ -92,7 +91,7 @@ def fun(q, log_message):
 
 def run_subprocess(log_message, queue):
     """Run a subprocess."""
-    from multiprocessing import get_context
+    freeze_support()
     ctx = get_context('spawn')
     proc = ctx.Process(target=fun, args=(queue, log_message))
     proc.start()

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Pytroll developers
+#
+# Author(s):
+#
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+"""Tests for the logging utilities."""
+
+import logging
+import time
+from logging.handlers import QueueHandler, BufferingHandler
+from unittest import mock
+
+import pytest
+
+from trollflow2.logging import logging_on
+
+
+def teardown_function():
+    """Clean up the handlers after execution."""
+    root = logging.getLogger()
+    while root.hasHandlers():
+        root.removeHandler(root.handlers[0])
+
+
+def test_logging_adds_one_queue_handlers(caplog):
+    """Test that logging adds a queue handler."""
+    log = logging.getLogger()
+    with logging_on():
+        log.warning('bla')
+        assert len(log.handlers) == 1
+        assert isinstance(log.handlers[0], QueueHandler)
+    assert "bla" in caplog.text
+
+
+def test_logging_is_queued_by_default():
+    """Test that logging is queued by default."""
+    log = logging.getLogger()
+    num_queued_handlers_before = count_queue_handlers(log)
+    with logging_on():
+        num_queued_handlers = count_queue_handlers(log)
+        assert num_queued_handlers > num_queued_handlers_before
+
+
+def count_queue_handlers(log):
+    """Count the number of queue handlers in the log handlers."""
+    num_queued_handlers = 0
+    for handler in log.handlers:
+        if isinstance(handler, logging.handlers.QueueHandler):
+            num_queued_handlers += 1
+    return num_queued_handlers
+
+
+def test_queued_logging_has_a_listener():
+    """Test that the queued logging has a listener."""
+    with mock.patch("trollflow2.logging.QueueListener", autospec=True) as q_listener:
+        with logging_on():
+            assert q_listener.called
+            assert q_listener.return_value.start.called
+        assert q_listener.return_value.stop.called
+
+
+def test_queued_logging_stops_listener_on_exception():
+    """Test that queued logging stops the listener even if an exception occurs."""
+    with mock.patch("trollflow2.logging.QueueListener", autospec=True) as q_listener:
+        with pytest.raises(Exception):
+            with logging_on():
+                raise Exception("Oh no!")
+        assert q_listener.return_value.stop.called
+
+
+LOG_CONFIG = {'version': 1,
+              'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
+              'handlers': {'file': {'class': 'logging.handlers.BufferingHandler',
+                                    'capacity': 1,
+                                    'formatter': 'simple'}},
+              'root': {'level': 'INFO', 'handlers': ['file']}}
+
+
+def test_log_config_is_used_when_provided():
+    """Test that the log config is used when provided."""
+    config = LOG_CONFIG
+
+    log = logging.getLogger()
+    with mock.patch("logging.handlers.BufferingHandler.emit", autospec=True) as emit:
+        with logging_on(config=config):
+            assert not emit.called
+            log.warning("uh oh...")
+            # we wait for the log record to go through the queue listener in
+            # its own thread
+            time.sleep(.01)
+            assert emit.called
+
+
+def test_log_config_still_uses_queuehandler():
+    """Test that the log config still uses the queuehandler."""
+    config = LOG_CONFIG
+
+    log = logging.getLogger()
+    with logging_on(config=config):
+        for handler in log.handlers:
+            assert not isinstance(handler, BufferingHandler)

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -31,7 +31,7 @@ import pytest
 from trollflow2.logging import logging_on
 
 
-def teardown_function():
+def setup_function():
     """Clean up the handlers after execution."""
     root = logging.getLogger()
     while root.hasHandlers():

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -98,6 +98,7 @@ def run_subprocess(log_message, queue):
     proc.start()
     proc.join()
 
+
 @pytest.mark.skipif(sys.platform != "linux",
                     reason="Logging from a subprocess seems to work only on Linux")
 def test_logging_works_in_subprocess(caplog):


### PR DESCRIPTION
It has been observed that trollflow2 v0.11.0 hangs quite often, probably due to a race condition in the logging code.

It is very likely that this bug has been introduced in #115, hence this attempt to make the QueueHandler usage more streamlined, independently of whether trollflow2 runs on threads or subprocesses, and more importantly by setting up the queued log handler and other handlers prior to running the main loop.

EDIT: for completeness, it should be noted that many live tests have been run with v0.10.0 at SMHI and that hanging specifically in the logging part was also happening.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Live test ran several days without crashing
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

