### PR TITLE
Add flag to create temporary file in temporary directory

### DIFF
--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -55,6 +55,8 @@ product_list: &product_list
   #   max: 80.0  # if higher than this, products are removed
   #   check_pass: True  # check coverage within the swath
   # min_coverage: 20  # at least 20% coverage
+  # use_tmp_file: True  # create temporary filename first
+  # use_tmp_dir: "/data/pytroll/tmp/staging_zone"  # create temporary files here first
 
   areas:
     omerc_bb:

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -55,8 +55,8 @@ product_list: &product_list
   #   max: 80.0  # if higher than this, products are removed
   #   check_pass: True  # check coverage within the swath
   # min_coverage: 20  # at least 20% coverage
-  # use_tmp_file: True  # create temporary filename first
-  # use_tmp_dir: "/data/pytroll/tmp/staging_zone"  # create temporary files here first
+  # use_tmp_file: False  # create temporary filename first
+  # staging_zone: "/data/pytroll/tmp/staging_zone"  # create files here first
 
   areas:
     omerc_bb:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -252,11 +252,16 @@ def renamed_files():
 def save_datasets(job):
     """Save the datasets (and trigger the computation).
 
-    If the `use_tmp_file` option is provided in the product list and is set to
+    If the ``use_tmp_file`` option is provided in the product list and is set to
     True, the file will be first saved to a temporary name before being renamed.
     This is useful when other processes are waiting for the file to be present
     to start their work, but would crash on incomplete files.
 
+    If, in addition, the ``use_tmp_dir`` option is provided in the product
+    list, then the temporary file will be created in this directory without
+    changing the filename.  This is useful for writers which write the filename
+    to the headers, such as the SatPy ninjotiff and ninjogeotiff writers.  The
+    value of ``use_tmp_dir`` has no effect if ``use_tmp_file`` is False.
     """
     scns = job['resampled_scenes']
     objs = []

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -190,14 +190,14 @@ def prepared_filename(fmat, renames):
 
     # tmp filenaming
     use_tmp_file = fmat.get('use_tmp_file', False)
-    use_tmp_dir = fmat.get("use_tmp_dir", False)
+    staging_zone = fmat.get("staging_zone", False)
 
-    if use_tmp_file:
-        if use_tmp_dir:
-            tmp_dir = pathlib.Path(use_tmp_dir)
+    if staging_zone or use_tmp_file:
+        if staging_zone:
+            directory = pathlib.Path(staging_zone)
             of = pathlib.Path(orig_filename)
-            filename = os.fspath(tmp_dir / of.name)
-        else:
+            filename = os.fspath(directory / of.name)
+        if use_tmp_file:
             filename = _get_temp_filename(directory, renames.keys())
         yield filename
         renames[filename] = orig_filename
@@ -257,11 +257,13 @@ def save_datasets(job):
     This is useful when other processes are waiting for the file to be present
     to start their work, but would crash on incomplete files.
 
-    If, in addition, the ``use_tmp_dir`` option is provided in the product
-    list, then the temporary file will be created in this directory without
+    If the ``staging_zone`` option is provided in the product
+    list, then the file will be created in this directory first, without
     changing the filename.  This is useful for writers which write the filename
     to the headers, such as the SatPy ninjotiff and ninjogeotiff writers.  The
-    value of ``use_tmp_dir`` has no effect if ``use_tmp_file`` is False.
+    ``staging_zone`` directory must be on the same filesystem as
+    ``output_dir``.  It is recommended to set ``use_tmp_file`` to `False` when
+    using a ``staging_zone`` directory.
     """
     scns = job['resampled_scenes']
     objs = []

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -22,6 +22,7 @@
 """Trollflow2 plugins."""
 
 import os
+import pathlib
 from contextlib import contextmanager
 from logging import getLogger
 from tempfile import NamedTemporaryFile
@@ -189,9 +190,15 @@ def prepared_filename(fmat, renames):
 
     # tmp filenaming
     use_tmp_file = fmat.get('use_tmp_file', False)
+    use_tmp_dir = fmat.get("use_tmp_dir", False)
 
     if use_tmp_file:
-        filename = _get_temp_filename(directory, renames.keys())
+        if use_tmp_dir:
+            tmp_dir = pathlib.Path(use_tmp_dir)
+            of = pathlib.Path(orig_filename)
+            filename = os.fspath(tmp_dir / of.name)
+        else:
+            filename = _get_temp_filename(directory, renames.keys())
         yield filename
         renames[filename] = orig_filename
     else:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -196,9 +196,10 @@ def prepared_filename(fmat, renames):
         if staging_zone:
             directory = pathlib.Path(staging_zone)
             of = pathlib.Path(orig_filename)
-            filename = os.fspath(directory / of.name)
         if use_tmp_file:
             filename = _get_temp_filename(directory, renames.keys())
+        else:
+            filename = os.fspath(directory / of.name)
         yield filename
         renames[filename] = orig_filename
     else:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -253,18 +253,22 @@ def renamed_files():
 def save_datasets(job):
     """Save the datasets (and trigger the computation).
 
-    If the ``use_tmp_file`` option is provided in the product list and is set to
-    True, the file will be first saved to a temporary name before being renamed.
-    This is useful when other processes are waiting for the file to be present
-    to start their work, but would crash on incomplete files.
+    If the ``use_tmp_file`` option is provided in the product list and
+    is set to True, the file will be first saved to a temporary name
+    before being renamed.  This is useful when other processes are
+    waiting for the file to be present to start their work, but would
+    crash on incomplete files.
 
-    If the ``staging_zone`` option is provided in the product
-    list, then the file will be created in this directory first, without
-    changing the filename.  This is useful for writers which write the filename
-    to the headers, such as the SatPy ninjotiff and ninjogeotiff writers.  The
-    ``staging_zone`` directory must be on the same filesystem as
-    ``output_dir``.  It is recommended to set ``use_tmp_file`` to `False` when
-    using a ``staging_zone`` directory.
+    If the ``staging_zone`` option is provided in the product list,
+    then the file will be created in this directory first, using either a
+    temporary filename (if ``use_tmp_file`` is true) or the final filename
+    (if ``use_tmp_file`` is false).  This is useful for writers which
+    write the filename to the headers, such as the Satpy ninjotiff and
+    ninjogeotiff writers.  The ``staging_zone`` directory must be on
+    the same filesystem as ``output_dir``.  When using those writers,
+    it is recommended to set ``use_tmp_file`` to `False` when using a
+    ``staging_zone`` directory, such that the filename written to the
+    headers remains meaningful.
     """
     scns = job['resampled_scenes']
     objs = []

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -327,6 +327,27 @@ class TestSaveDatasets(TestCase):
         self.assertTrue(os.path.exists(tst_dir))
         os.rmdir(tst_dir)
 
+    def test_use_tmp_dir(self):
+        """Test `prepared_filename` context with temporary directory.
+
+        Test that when both use_tmp_file and use_tmp_dir are set, that the
+        temporary file is created in its own temporary directory, whereas the
+        basename is not changed.
+        """
+        from trollflow2.plugins import prepared_filename
+        tst_file = "trappedinaunittest.tif"
+
+        renames = {}
+        fmat = {"use_tmp_file": True, "fname_pattern": tst_file,
+                "use_tmp_dir": "/tmp/abcd"}
+        with prepared_filename(fmat, renames) as filename:
+            pass
+        assert filename != tst_file
+        assert filename.endswith(tst_file)
+        assert len(renames) == 1
+        assert next(iter(renames.values())) == tst_file
+        assert next(iter(renames.keys())).startswith("/tmp/abcd/")
+
     def test_prepare_filename_and_directory(self):
         """Test filename composition and directory creation."""
         from trollflow2.plugins import _prepare_filename_and_directory

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -339,14 +339,14 @@ class TestSaveDatasets(TestCase):
 
         renames = {}
         fmat = {"use_tmp_file": True, "fname_pattern": tst_file,
-                "use_tmp_dir": "/tmp/abcd"}
+                "use_tmp_dir": "/dummy/abcd"}
         with prepared_filename(fmat, renames) as filename:
             pass
         assert filename != tst_file
         assert filename.endswith(tst_file)
         assert len(renames) == 1
         assert next(iter(renames.values())) == tst_file
-        assert next(iter(renames.keys())).startswith("/tmp/abcd/")
+        assert next(iter(renames.keys())).startswith("/dummy/abcd/")
 
     def test_prepare_filename_and_directory(self):
         """Test filename composition and directory creation."""


### PR DESCRIPTION
Add an option to create the temporary file in a temporary directory, respecting the basename.  This will close #125.  We need this so that the filename passed to the writer and therefore the contents of the filename tag in ninjogeotiff files remains meaningful.

 - [x] Closes #125 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
