### PR TITLE
Fix scene attribute usage in sza_check

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -528,8 +528,9 @@ def metadata_alias(job):
 
 def sza_check(job):
     """Remove products which are not valid for the current Sun zenith angle."""
-    scn = job['scene']
-    start_time = scn.attrs['start_time']
+    scn_mda = job['scene'].attrs.copy()
+    scn_mda.update(job['input_mda'])
+    start_time = scn_mda['start_time']
     product_list = job['product_list']
     areas = list(product_list['product_list']['areas'].keys())
     for area in areas:

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1326,7 +1326,8 @@ class TestSZACheck(TestCase):
 def _create_job(product_list):
     job = {}
     scene = mock.MagicMock()
-    scene.attrs = {'start_time': 42}
+    scene.attrs = {}
+    job['input_mda'] = {'start_time': 42, 'another_message_item': 'coconut'}
     job['scene'] = scene
     job['product_list'] = product_list.copy()
 


### PR DESCRIPTION
Recent Satpy doesn't have anything in the Scene attributes, so we need to merge input metadata to it. This was already done in most of the plugins, but not in `sza_check`. This PR refactors the tests for this plugin, and implements a fix to the missing start time.

 - [x] Closes https://github.com/pytroll/satpy/issues/1943 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
