### PR TITLE
More verbose logging when removing due to lack of sunlight

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -644,11 +644,13 @@ def check_sunlight_coverage(job):
             area_conf['area_sunlight_coverage_percent'] = coverage[use_pass] * 100
             if min_day is not None and coverage[use_pass] < (min_day / 100.0):
                 LOG.info("Not enough sunlight coverage for "
-                         "product '%s', removed.", product)
+                         f"product '{product!s}', removed. Needs at least "
+                         f"{min_day:.1f}%, got {coverage[use_pass]:.1%}.")
                 dpath.util.delete(product_list, prod_path)
             if max_day is not None and coverage[use_pass] > (max_day / 100.0):
                 LOG.info("Too much sunlight coverage for "
-                         "product '%s', removed.", product)
+                         f"product '{product!s}', removed. Needs at most "
+                         f"{max_day:.1f}%, got {coverage[use_pass]:.1%}.")
                 dpath.util.delete(product_list, prod_path)
 
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1040,13 +1040,21 @@ class TestCheckSunlightCoverage(TestCase):
             self.assertIn('green_snow', job['product_list']['product_list']['areas']['euron1']['products'])
 
             _get_sunlight_coverage.return_value = 0
-            check_sunlight_coverage(job)
+            with self.assertLogs("trollflow2.plugins", level=logging.INFO) as cm:
+                check_sunlight_coverage(job)
             self.assertNotIn('green_snow', job['product_list']['product_list']['areas']['euron1']['products'])
+            self.assertIn("Not enough sunlight coverage for product "
+                          "'green_snow', removed. Needs at least 10.0%, got "
+                          "0.0%.", cm.output[0])
 
             job['product_list']['product_list']['areas']['euron1']['products']['green_snow'] = pl_green
             _get_sunlight_coverage.return_value = 1
-            check_sunlight_coverage(job)
+            with self.assertLogs("trollflow2.plugins", level=logging.INFO) as cm:
+                check_sunlight_coverage(job)
             self.assertNotIn('green_snow', job['product_list']['product_list']['areas']['euron1']['products'])
+            self.assertIn("Too much sunlight coverage for product "
+                          "'green_snow', removed. Needs at most 40.0%, got "
+                          "100.0%.", cm.output[0])
 
 
 class TestCovers(TestCase):


### PR DESCRIPTION
When a product is removed due to insufficient sunlight coverage, include
information about the detected amount of sunlight converage.  This might
help debugging in cases when scenes are unexpectedly removed.

Example of new logging:

```
[2021-12-29 12:30:01,093 INFO     trollflow2.plugins] Not enough sunlight coverage for product 'snow_age', removed. Needs at least 5.0%, got 0.0%.
[2021-12-29 12:30:01,095 INFO     trollflow2.plugins] Not enough sunlight coverage for product 'true_color', removed. Needs at least 5.0%, got 0.0%.
[2021-12-29 12:30:01,098 INFO     trollflow2.plugins] Not enough sunlight coverage for product 'overview', removed. Needs at least 5.0%, got 0.0%.
[2021-12-29 12:30:01,100 INFO     trollflow2.plugins] Not enough sunlight coverage for product 'cloud_phase_distinction', removed. Needs at least 5.0%, got 0.0%.
[2021-12-29 12:30:01,102 INFO     trollflow2.plugins] Not enough sunlight coverage for product 'cloud_phase', removed. Needs at least 5.0%, got 0.0%.
[2021-12-29 12:30:01,104 INFO     trollflow2.plugins] Not enough sunlight coverage for product 'cloud_type', removed. Needs at least 5.0%, got 0.0%.
```

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #130 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
