### PR TITLE
Remove dpath version restriction and fix the import

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -U codecov pytest pytest-cov pyyaml "dpath<1.5" trollsift six numpy satpy rasterio posttroll pyorbital
+          pip install -U codecov pytest pytest-cov pyyaml dpath trollsift six numpy satpy rasterio posttroll pyorbital
 
       - name: Install unstable dependencies
         if: matrix.experimental == true

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except ImportError:
     pass
 
 
-install_requires = ['pyyaml', 'dpath<=1.5', 'trollsift']
+install_requires = ['pyyaml', 'dpath', 'trollsift']
 
 if "test" not in sys.argv:
     install_requires += ['posttroll', 'satpy', 'pyorbital']

--- a/trollflow2/dict_tools.py
+++ b/trollflow2/dict_tools.py
@@ -20,7 +20,7 @@
 # are not necessary
 """Tools for product list operations."""
 
-import dpath
+import dpath.util
 
 
 def plist_iter(product_list, base_mda=None, level=None):

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -127,7 +127,7 @@ def resample(job):
         area_conf = _get_plugin_conf(product_list, '/product_list/areas/' + str(area),
                                      conf)
         LOG.debug('Resampling to %s', str(area))
-        if area is None:
+        if area == 'None':
             minarea = get_config_value(product_list,
                                        '/product_list/areas/' + str(area),
                                        'use_min_area')

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -28,7 +28,7 @@ from logging import getLogger
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlunsplit
 
-import dpath
+import dpath.util
 import rasterio
 import dask
 from posttroll.message import Message

--- a/trollflow2/tests/test_dict_tools.py
+++ b/trollflow2/tests/test_dict_tools.py
@@ -85,7 +85,7 @@ product_list:
                 writer: geotiff
 
       null:
-        areaname: germ_in_fname
+        areaname: null_in_fname
         fname_pattern: "{start_time:%Y%m%d_%H%M}_{areaname:s}_{productname}.{format}"
         products:
           cloudtype:

--- a/trollflow2/tests/test_dict_tools.py
+++ b/trollflow2/tests/test_dict_tools.py
@@ -23,11 +23,6 @@
 """Test the product list tools."""
 
 import unittest
-import yaml
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader
 try:
     from unittest import mock
 except ImportError:
@@ -39,6 +34,9 @@ try:
     import numpy  # noqa
 except ImportError:
     pass
+
+from trollflow2.launcher import read_config
+
 
 yaml_test1 = """
 product_list:
@@ -166,7 +164,7 @@ class TestProdList(unittest.TestCase):
     def test_iter(self):
         """Test plist_iter."""
         from trollflow2.dict_tools import plist_iter
-        prodlist = yaml.load(yaml_test1, Loader=UnsafeLoader)['product_list']
+        prodlist = read_config(raw_string=yaml_test1)['product_list']
         expected = [{'areaname': 'euron1_in_fname', 'area': 'euron1', 'productname': 'cloud_top_height_in_fname', 'product': 'cloud_top_height',  # noqa
                      'min_coverage': 20.0, 'something': 'foo',
                      'output_dir': '/tmp/satdmz/pps/www/latest_2018/', 'format': 'png', 'writer': 'simple_image',
@@ -187,7 +185,7 @@ class TestProdList(unittest.TestCase):
         for i, exp in zip(plist_iter(prodlist), expected):
             self.assertDictEqual(i[0], exp)
 
-        prodlist = yaml.load(yaml_test2, Loader=UnsafeLoader)['product_list']
+        prodlist = read_config(raw_string=yaml_test2)['product_list']
         for i, exp in zip(plist_iter(prodlist), expected):
             self.assertDictEqual(i[0], exp)
 
@@ -197,7 +195,7 @@ class TestConfigValue(unittest.TestCase):
 
     def setUp(self):
         """Set up the test case."""
-        self.prodlist = yaml.load(yaml_test1, Loader=UnsafeLoader)
+        self.prodlist = read_config(raw_string=yaml_test1)
         self.path = "/product_list/areas/germ/products/cloudtype"
 
     def test_config_value_same_level(self):

--- a/trollflow2/tests/test_dict_tools.py
+++ b/trollflow2/tests/test_dict_tools.py
@@ -85,6 +85,18 @@ product_list:
             formats:
               - format: tif
                 writer: geotiff
+
+      null:
+        areaname: germ_in_fname
+        fname_pattern: "{start_time:%Y%m%d_%H%M}_{areaname:s}_{productname}.{format}"
+        products:
+          cloudtype:
+            productname: cloudtype_in_fname
+            output_dir: /tmp/satdmz/pps/www/latest_2018/
+            formats:
+              - format: png
+                writer: simple_image
+
 """
 
 yaml_test2 = """
@@ -221,6 +233,13 @@ class TestConfigValue(unittest.TestCase):
         res = get_config_value(self.prodlist, self.path, "nothing",
                                default=42)
         self.assertEqual(res, 42)
+
+    def test_null_area(self):
+        from trollflow2.dict_tools import get_config_value
+        path = "/product_list/areas/None/products/cloudtype"
+        expected = "/tmp/satdmz/pps/www/latest_2018/"
+        res = get_config_value(self.prodlist, path, "output_dir")
+        self.assertEqual(res, expected)
 
 
 if __name__ == '__main__':

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -32,6 +32,7 @@ from unittest import mock
 import pytest
 
 from trollflow2.tests.utils import TestCase
+from trollflow2.launcher import read_config
 
 
 yaml_test1 = """
@@ -362,12 +363,12 @@ class TestSaveDatasets(TestCase):
     def test_save_datasets(self):
         """Test saving datasets."""
         self.maxDiff = None
-        from trollflow2.launcher import yaml, UnsafeLoader
+        from yaml import UnsafeLoader
         from trollflow2.plugins import save_datasets, DEFAULT
         job = {}
         job['input_mda'] = input_mda
         job['product_list'] = {
-            'product_list': yaml.load(yaml_test_save, Loader=UnsafeLoader)['product_list'],
+            'product_list': read_config(raw_string=yaml_test_save, Loader=UnsafeLoader)['product_list'],
         }
         job['resampled_scenes'] = {}
         the_queue = mock.MagicMock()
@@ -630,8 +631,8 @@ class TestLoadComposites(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test1, Loader=UnsafeLoader)
 
     def test_load_composites(self):
         """Test loading composites."""
@@ -670,8 +671,8 @@ class TestAggregate(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test1, Loader=UnsafeLoader)
 
     def test_aggregate_returns_aggregated_scene(self):
         """Test aggregating."""
@@ -708,8 +709,8 @@ class TestResample(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test1, Loader=UnsafeLoader)
 
     def test_resample(self):
         """Test resampling."""
@@ -767,7 +768,7 @@ class TestResample(TestCase):
         scn = mock.MagicMock()
         scn.resample.return_value = "foo"
         job = {"scene": scn, "product_list": self.product_list.copy()}
-        job['product_list']['product_list']['areas'][None] = job['product_list']['product_list']['areas']['germ']
+        job['product_list']['product_list']['areas']['None'] = job['product_list']['product_list']['areas']['germ']
         del job['product_list']['product_list']['areas']['germ']
         resample(job)
         self.assertTrue(mock.call('omerc_bb',
@@ -786,7 +787,7 @@ class TestResample(TestCase):
                                   mask_area=False,
                                   epsilon=0.0) in
                         scn.resample.mock_calls)
-        self.assertTrue(job['resampled_scenes'][None] is scn)
+        self.assertTrue(job['resampled_scenes']['None'] is scn)
         self.assertTrue("resampled_scenes" in job)
         for area in ["omerc_bb", "euron1"]:
             self.assertTrue(area in job["resampled_scenes"])
@@ -798,8 +799,8 @@ class TestResample(TestCase):
         scn = mock.MagicMock()
         scn.resample.return_value = "foo"
         product_list = self.product_list.copy()
-        product_list['product_list']['areas'][None] = product_list['product_list']['areas']['germ']
-        product_list['product_list']['areas'][None]['use_min_area'] = True
+        product_list['product_list']['areas']['None'] = product_list['product_list']['areas']['germ']
+        product_list['product_list']['areas']['None']['use_min_area'] = True
         del product_list['product_list']['areas']['germ']
         del product_list['product_list']['areas']['omerc_bb']
         del product_list['product_list']['areas']['euron1']
@@ -813,8 +814,8 @@ class TestResample(TestCase):
                                   mask_area=False,
                                   epsilon=0.0) in
                         scn.resample.mock_calls)
-        del product_list['product_list']['areas'][None]['use_min_area']
-        product_list['product_list']['areas'][None]['use_max_area'] = True
+        del product_list['product_list']['areas']['None']['use_min_area']
+        product_list['product_list']['areas']['None']['use_max_area'] = True
         job = {"scene": scn, "product_list": product_list.copy()}
         resample(job)
         self.assertTrue(mock.call(scn.max_area(),
@@ -833,8 +834,8 @@ class TestResampleNullArea(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test_null_area, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test_null_area, Loader=UnsafeLoader)
 
     def test_resample_null_area(self):
         """Test handling a `None` area in resampling."""
@@ -865,8 +866,8 @@ class TestResampleNullArea(TestCase):
         scn.keys.return_value = ['abc']
         scn.wishlist = {'abc'}
         resample(job)
-        self.assertTrue(mock.call(resampler='native') in
-                        scn.resample.mock_calls)
+        self.assertTrue("resampler='native'" in
+                        str(scn.resample.mock_calls))
 
 
 class TestSunlightCovers(TestCase):
@@ -875,8 +876,8 @@ class TestSunlightCovers(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test1, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
                           "start_time": dt.datetime(2019, 4, 7, 20, 52),
@@ -972,8 +973,8 @@ class TestCheckSunlightCoverage(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test3, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test3, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
                           "start_time": dt.datetime(2019, 1, 19, 11),
@@ -1055,8 +1056,8 @@ class TestCovers(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test1, Loader=UnsafeLoader)
         self.input_mda = {"platform_name": "NOAA-15",
                           "sensor": "avhrr-3",
                           "start_time": dt.datetime(2019, 1, 19, 11),
@@ -1317,8 +1318,8 @@ class TestSZACheck(TestCase):
 
 
 def _get_product_list_and_job(add_sza_limits=False):
-    from trollflow2.launcher import yaml, UnsafeLoader
-    product_list = yaml.load(yaml_test1, Loader=UnsafeLoader)
+    from yaml import UnsafeLoader
+    product_list = read_config(raw_string=yaml_test1, Loader=UnsafeLoader)
     if add_sza_limits:
         _add_sunzen_limits(product_list)
     job = _create_job(product_list)
@@ -1355,8 +1356,8 @@ class TestOverviews(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, BaseLoader
-        self.product_list = yaml.load(yaml_test1, Loader=BaseLoader)
+        from yaml import BaseLoader
+        self.product_list = read_config(raw_string=yaml_test1, Loader=BaseLoader)
 
     def test_add_overviews(self):
         """Test adding overviews."""
@@ -1384,8 +1385,8 @@ class TestFilePublisher(TestCase):
     def setUp(self):
         """Set up the test case."""
         super().setUp()
-        from trollflow2.launcher import yaml, UnsafeLoader
-        self.product_list = yaml.load(yaml_test_publish, Loader=UnsafeLoader)
+        from yaml import UnsafeLoader
+        self.product_list = read_config(raw_string=yaml_test_publish, Loader=UnsafeLoader)
         # Skip omerc_bb area, there's no fname_pattern
         del self.product_list['product_list']['areas']['omerc_bb']
         self.input_mda = input_mda.copy()
@@ -1494,7 +1495,7 @@ class TestFilePublisher(TestCase):
 
         scn = mock.MagicMock()
         job = {"scene": scn, "product_list": self.product_list, 'input_mda': self.input_mda,
-               'resampled_scenes': {None: resampled_scene}}
+               'resampled_scenes': {'None': resampled_scene}}
 
         with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher'):
             self._run_publisher_on_job(job)
@@ -1535,7 +1536,7 @@ class TestFilePublisher(TestCase):
 
     def test_filepublisher_kwargs(self):
         """Test filepublisher keyword argument usage."""
-        import yaml
+        from yaml import UnsafeLoader
         from trollflow2.plugins import FilePublisher
 
         # Direct instantiation
@@ -1573,7 +1574,7 @@ class TestFilePublisher(TestCase):
             NoisyPublisher = mocks['NoisyPublisher']
             Publisher = mocks['Publisher']
 
-            fpub = yaml.load(YAML_FILE_PUBLISHER, Loader=yaml.UnsafeLoader)
+            fpub = read_config(raw_string=YAML_FILE_PUBLISHER, Loader=UnsafeLoader)
             assert mock.call('l2processor', port=40002,
                              nameservers=['localhost']) in NoisyPublisher.mock_calls
             Publisher.assert_not_called()


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

We've had a version limitation `dpath<1.5` as it seemed the `.util` sub-package didn't exist after that. That was not the case, and everything works if we do `import dpath.util`. This fixes the imports, and removes the version restriction.

Internally "use satellite projection", which in the product list is marked by using `null` as area name, now uses `'None'` as the newer versions of `dpath` only support string and integer names.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
