### PR TITLE
Use UnsafeLoader when reading product list for process()

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -345,7 +345,7 @@ def print_traces(signum, frame):
 
 def process(msg, prod_list, produced_files):
     """Process a message."""
-    config = read_config(prod_list)
+    config = read_config(prod_list, Loader=UnsafeLoader)
 
     # Get distributed client
     client = get_dask_client(config)

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -601,8 +601,6 @@ def test_workers_initialized():
                     process("msg", fname, queue)
                 except StopIteration:
                     pass
-                else:
-                    raise
         finally:
             os.remove(fname)
 

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -119,12 +119,12 @@ product_list:
           night_fog:
             productname: night_fog
 
-# workers:
-#   - fun: !!python/name:trollflow2.create_scene
-#   - fun: !!python/name:trollflow2.load_composites
-#   - fun: !!python/name:trollflow2.resample
-#   - fun: !!python/name:trollflow2.save_datasets
-#   - fun: !!python/object:trollflow2.FilePublisher {}
+workers:
+  - fun: !!python/name:trollflow2.plugins.create_scene
+  - fun: !!python/name:trollflow2.plugins.load_composites
+  - fun: !!python/name:trollflow2.plugins.resample
+  - fun: !!python/name:trollflow2.plugins.save_datasets
+#  - fun: !!python/object:trollflow2.FilePublisher {}
 """
 
 
@@ -579,6 +579,31 @@ class TestProcess(TestCase):
             process("msg", "prod_list", self.queue)
         # wait a little to ensure alarm is not raised later
         time.sleep(0.11)
+
+def test_workers_initialized():
+    """Test that the config loading works when workers are defined."""
+    from tempfile import NamedTemporaryFile
+    import os
+
+    queue = mock.MagicMock()
+
+    with NamedTemporaryFile(mode='w+t', delete=False) as tmp_file:
+        fname = tmp_file.name
+        tmp_file.write(yaml_test_minimal)
+        tmp_file.close()
+
+        try:
+            with mock.patch("trollflow2.launcher.get_dask_client") as gdc:
+                # `get_dask_client()` is called just after config reading, so if we get there loading worked
+                gdc.side_effect = StopIteration
+                try:
+                    process("msg", fname, queue)
+                except StopIteration:
+                    pass
+                else:
+                    raise
+        finally:
+            os.remove(fname)
 
 
 def test_get_dask_client(caplog):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -580,6 +580,7 @@ class TestProcess(TestCase):
         # wait a little to ensure alarm is not raised later
         time.sleep(0.11)
 
+
 def test_workers_initialized():
     """Test that the config loading works when workers are defined."""
     from tempfile import NamedTemporaryFile


### PR DESCRIPTION
In #134 the config reading was refactored, and the `Loader` kwarg was accidentally changed when the product list is read.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
