### PR TITLE
Use scene properties instead of .attrs where needed

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
   - dpath
   - trollsift
   - numpy
-  - satpy
+  - satpy>=0.32.0
   - rasterio
   - pyorbital
   - pip:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ except ImportError:
 install_requires = ['pyyaml', 'dpath', 'trollsift']
 
 if "test" not in sys.argv:
-    install_requires += ['posttroll', 'satpy', 'pyorbital']
+    install_requires += ['posttroll', 'satpy>=0.32.0', 'pyorbital']
 
 NAME = 'trollflow2'
 README = open('README.md', 'r').read()

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -414,7 +414,8 @@ def covers(job):
     product_list = job['product_list'].copy()
 
     scn_mda = {"start_time": job['scene'].start_time,
-               "end_time": job['scene'].end_time}
+               "end_time": job['scene'].end_time,
+               "sensor": job['scene'].sensors}
     scn_mda.update(job['input_mda'])
 
     platform_name = scn_mda['platform_name']

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -415,7 +415,7 @@ def covers(job):
 
     scn_mda = {"start_time": job['scene'].start_time,
                "end_time": job['scene'].end_time,
-               "sensor": job['scene'].sensors}
+               "sensor": job['scene'].sensor_names}
     scn_mda.update(job['input_mda'])
 
     platform_name = scn_mda['platform_name']
@@ -594,7 +594,7 @@ def check_sunlight_coverage(job):
 
     scn_mda = {"start_time": job['scene'].start_time,
                "end_time": job['scene'].end_time,
-               "sensor": job['scene'].sensors}
+               "sensor": job['scene'].sensor_names}
     scn_mda.update(job['input_mda'])
     platform_name = scn_mda['platform_name']
     start_time = scn_mda['start_time']

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -413,7 +413,9 @@ def covers(job):
 
     product_list = job['product_list'].copy()
 
-    scn_mda = job['scene'].attrs.copy()
+    scn_mda = {"start_time": job['scene'].start_time,
+               "end_time": job['scene'].end_time,
+               "platform_name": job['scene'].platform_name}
     scn_mda.update(job['input_mda'])
 
     platform_name = scn_mda['platform_name']
@@ -528,7 +530,7 @@ def metadata_alias(job):
 
 def sza_check(job):
     """Remove products which are not valid for the current Sun zenith angle."""
-    scn_mda = job['scene'].attrs.copy()
+    scn_mda = {"start_time": job['scene'].start_time}
     scn_mda.update(job['input_mda'])
     start_time = scn_mda['start_time']
     product_list = job['product_list']
@@ -590,7 +592,9 @@ def check_sunlight_coverage(job):
         LOG.info("Keeping all products")
         return
 
-    scn_mda = job['scene'].attrs.copy()
+    scn_mda = {"start_time": job['scene'].start_time,
+               "end_time": job['scene'].end_time,
+               "platform_name": job['scene'].platform_name}
     scn_mda.update(job['input_mda'])
     platform_name = scn_mda['platform_name']
     start_time = scn_mda['start_time']

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -414,8 +414,7 @@ def covers(job):
     product_list = job['product_list'].copy()
 
     scn_mda = {"start_time": job['scene'].start_time,
-               "end_time": job['scene'].end_time,
-               "platform_name": job['scene'].platform_name}
+               "end_time": job['scene'].end_time}
     scn_mda.update(job['input_mda'])
 
     platform_name = scn_mda['platform_name']
@@ -594,7 +593,7 @@ def check_sunlight_coverage(job):
 
     scn_mda = {"start_time": job['scene'].start_time,
                "end_time": job['scene'].end_time,
-               "platform_name": job['scene'].platform_name}
+               "sensor": job['scene'].sensors}
     scn_mda.update(job['input_mda'])
     platform_name = scn_mda['platform_name']
     start_time = scn_mda['start_time']

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -413,9 +413,7 @@ def covers(job):
 
     product_list = job['product_list'].copy()
 
-    scn_mda = {"start_time": job['scene'].start_time,
-               "end_time": job['scene'].end_time,
-               "sensor": job['scene'].sensor_names}
+    scn_mda = _get_scene_metadata(job)
     scn_mda.update(job['input_mda'])
 
     platform_name = scn_mda['platform_name']
@@ -434,6 +432,13 @@ def covers(job):
             sensor, job["scene"])
 
     job['product_list'] = product_list
+
+
+def _get_scene_metadata(job):
+    scn_mda = {"start_time": job['scene'].start_time,
+               "end_time": job['scene'].end_time,
+               "sensor": job['scene'].sensor_names}
+    return scn_mda
 
 
 def _check_coverage_for_area(
@@ -530,7 +535,7 @@ def metadata_alias(job):
 
 def sza_check(job):
     """Remove products which are not valid for the current Sun zenith angle."""
-    scn_mda = {"start_time": job['scene'].start_time}
+    scn_mda = _get_scene_metadata(job)
     scn_mda.update(job['input_mda'])
     start_time = scn_mda['start_time']
     product_list = job['product_list']
@@ -592,9 +597,7 @@ def check_sunlight_coverage(job):
         LOG.info("Keeping all products")
         return
 
-    scn_mda = {"start_time": job['scene'].start_time,
-               "end_time": job['scene'].end_time,
-               "sensor": job['scene'].sensor_names}
+    scn_mda = _get_scene_metadata(job)
     scn_mda.update(job['input_mda'])
     platform_name = scn_mda['platform_name']
     start_time = scn_mda['start_time']

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -995,13 +995,14 @@ class TestCheckSunlightCoverage(TestCase):
             scene.attrs = {}
             scene.start_time = 42
             scene.end_time = 43
-            scene.platform_name = 'platform'
-            job = {"scene": scene, "product_list": self.product_list.copy(), "input_mda": {"sensor": "sensor"}}
+            scene.sensors = {'sensor'}
+            job = {"scene": scene, "product_list": self.product_list.copy(),
+                   "input_mda": {"platform_name": "platform"}}
             job['product_list']['product_list']['sunlight_coverage'] = {'min': 10, 'max': 40, 'check_pass': True}
             # job["product_list"]["product_list"]["use_pass"] = True
             check_sunlight_coverage(job)
-            ts_pass.assert_called_with(scene.platform_name, scene.start_time, scene.end_time,
-                                       instrument=job["input_mda"]["sensor"])
+            ts_pass.assert_called_with(job["input_mda"]["platform_name"], scene.start_time, scene.end_time,
+                                       instrument=list(scene.sensors)[0])
 
     def test_product_not_loaded(self):
         """Test that product isn't loaded when sunlight coverage is too low."""
@@ -1113,12 +1114,11 @@ class TestCovers(TestCase):
             scn.attrs = {}
             scn.start_time = 42
             scn.end_time = 43
-            scn.platform_name = 'platform'
             job = {"product_list": self.product_list,
-                   "input_mda": {"sensor": "avhrr-3"},
+                   "input_mda": {"sensor": "avhrr-3", "platform_name": "platform"},
                    "scene": scn}
             covers(job)
-            get_scene_coverage.assert_called_with(scn.platform_name,
+            get_scene_coverage.assert_called_with(job["input_mda"]["platform_name"],
                                                   scn.start_time,
                                                   scn.end_time,
                                                   "avhrr-3",

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -995,14 +995,14 @@ class TestCheckSunlightCoverage(TestCase):
             scene.attrs = {}
             scene.start_time = 42
             scene.end_time = 43
-            scene.sensors = {'sensor'}
+            scene.sensor_names = {'sensor'}
             job = {"scene": scene, "product_list": self.product_list.copy(),
                    "input_mda": {"platform_name": "platform"}}
             job['product_list']['product_list']['sunlight_coverage'] = {'min': 10, 'max': 40, 'check_pass': True}
             # job["product_list"]["product_list"]["use_pass"] = True
             check_sunlight_coverage(job)
             ts_pass.assert_called_with(job["input_mda"]["platform_name"], scene.start_time, scene.end_time,
-                                       instrument=list(scene.sensors)[0])
+                                       instrument=list(scene.sensor_names)[0])
 
     def test_product_not_loaded(self):
         """Test that product isn't loaded when sunlight coverage is too low."""
@@ -1114,7 +1114,7 @@ class TestCovers(TestCase):
             scn.attrs = {}
             scn.start_time = 42
             scn.end_time = 43
-            scn.sensors = {"sensor"}
+            scn.sensor_names = {"sensor"}
             job = {"product_list": self.product_list,
                    "input_mda": {"platform_name": "platform"},
                    "scene": scn}
@@ -1122,7 +1122,7 @@ class TestCovers(TestCase):
             get_scene_coverage.assert_called_with(job["input_mda"]["platform_name"],
                                                   scn.start_time,
                                                   scn.end_time,
-                                                  list(scn.sensors)[0],
+                                                  list(scn.sensor_names)[0],
                                                   "omerc_bb")
 
     def test_covers(self):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1114,14 +1114,15 @@ class TestCovers(TestCase):
             scn.attrs = {}
             scn.start_time = 42
             scn.end_time = 43
+            scn.sensors = {"sensor"}
             job = {"product_list": self.product_list,
-                   "input_mda": {"sensor": "avhrr-3", "platform_name": "platform"},
+                   "input_mda": {"platform_name": "platform"},
                    "scene": scn}
             covers(job)
             get_scene_coverage.assert_called_with(job["input_mda"]["platform_name"],
                                                   scn.start_time,
                                                   scn.end_time,
-                                                  "avhrr-3",
+                                                  list(scn.sensors)[0],
                                                   "omerc_bb")
 
     def test_covers(self):


### PR DESCRIPTION
In Satpy the `Scene` object no longer have metadata in the `.attrs` dictionary. This PR replaces that usage by collecting the relevant items from the `.start_time`, `.end_time` and `.sensor_names` attributes/properties where required.

The required Satpy version is set to `>=0.32.0` to be certain `.sensor_names` attribute is present.

 - [x] Closes #136  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
