### PR TITLE
Make it possible to do eager saving

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -151,6 +151,13 @@ are several options:
 The ``fname_pattern`` can be a global setting at the top-level of the
 configuration, and overridden on area and product levels.
 
+It is possible to force the saving to be eager by defining
+``eager_writing: True`` in the product list. Eager saving means that
+each dataset are saved separately. The usage of this will most likely
+increase the processing time by a significant amount, but it is
+necessary until a `bug in XArray NetCDF4
+<https://github.com/pydata/xarray/issues/6300>`_ handling is fixed.
+
 Messaging for saved datasets
 ****************************
 

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -57,6 +57,9 @@ product_list: &product_list
   # min_coverage: 20  # at least 20% coverage
   # use_tmp_file: False  # create temporary filename first
   # staging_zone: "/data/pytroll/tmp/staging_zone"  # create files here first
+  # Force eager writing and computation of datasets.
+  #   Required when saving several datasets to a single CF/NetCDF4 file.
+  # eager_writing: True
 
   areas:
     omerc_bb:

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -58,7 +58,10 @@ product_list: &product_list
   # use_tmp_file: False  # create temporary filename first
   # staging_zone: "/data/pytroll/tmp/staging_zone"  # create files here first
   # Force eager writing and computation of datasets.
-  #   Required when saving several datasets to a single CF/NetCDF4 file.
+  #   Required when saving several datasets to a single CF/NetCDF4 file until
+  #   the bug in XArray NetCDF4 handling has been fixed. This option will most
+  #   likely increase the required processing time.
+  #   Issue on the XArray bug: https://github.com/pydata/xarray/issues/6300
   # eager_writing: True
 
   areas:

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -367,18 +367,11 @@ class TestSaveDatasets(TestCase):
     def test_save_datasets(self):
         """Test saving datasets."""
         self.maxDiff = None
-        from yaml import UnsafeLoader
         from trollflow2.plugins import save_datasets, DEFAULT
-        job = {}
-        job['input_mda'] = input_mda
-        job['product_list'] = {
-            'product_list': read_config(raw_string=yaml_test_save, Loader=UnsafeLoader)['product_list'],
-        }
-        job['resampled_scenes'] = {}
+
         the_queue = mock.MagicMock()
+        job = _create_job_for_save_datasets()
         job['produced_files'] = the_queue
-        for area in job['product_list']['product_list']['areas']:
-            job['resampled_scenes'][area] = mock.Mock()
         with mock.patch('trollflow2.plugins.compute_writer_results'),\
                 mock.patch('trollflow2.plugins.DataQuery') as dsid,\
                 mock.patch('os.rename') as rename:
@@ -552,6 +545,19 @@ class TestSaveDatasets(TestCase):
                      '/tmp/NOAA-15_20190217_0600_omerc_bb_cloud_top_height.tif']
         for fname, efname in zip(the_queue.put.mock_calls, filenames):
             self.assertEqual(fname, mock.call(efname))
+
+
+def _create_job_for_save_datasets():
+    from yaml import UnsafeLoader
+    job = {}
+    job['input_mda'] = input_mda
+    job['product_list'] = {
+        'product_list': read_config(raw_string=yaml_test_save, Loader=UnsafeLoader)['product_list'],
+    }
+    job['resampled_scenes'] = {}
+    for area in job['product_list']['product_list']['areas']:
+        job['resampled_scenes'][area] = mock.Mock()
+    return job
 
 
 def test_use_staging_zone_no_tmpfile():

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -546,6 +546,25 @@ class TestSaveDatasets(TestCase):
         for fname, efname in zip(the_queue.put.mock_calls, filenames):
             self.assertEqual(fname, mock.call(efname))
 
+    def test_save_datasets_eager(self):
+        """Test saving datasets in eager manner."""
+        from trollflow2.plugins import save_datasets
+
+        job = _create_job_for_save_datasets()
+        job['product_list']['product_list']['eager_writing'] = True
+        with mock.patch('trollflow2.plugins.compute_writer_results') as compute_writer_results,\
+                mock.patch('trollflow2.plugins.DataQuery'),\
+                mock.patch('os.rename'):
+            save_datasets(job)
+            sd_calls = (job['resampled_scenes']['euron1'].save_dataset.mock_calls
+                        + job['resampled_scenes']['omerc_bb'].save_dataset.mock_calls)
+            for sd in sd_calls:
+                assert "compute=True" in str(sd)
+            sds_calls = job['resampled_scenes']['euron1'].save_datasets.mock_calls
+            for sds in sds_calls:
+                assert "compute=True" in str(sds)
+            compute_writer_results.assert_not_called()
+
 
 def _create_job_for_save_datasets():
     from yaml import UnsafeLoader
@@ -555,6 +574,7 @@ def _create_job_for_save_datasets():
         'product_list': read_config(raw_string=yaml_test_save, Loader=UnsafeLoader)['product_list'],
     }
     job['resampled_scenes'] = {}
+    job['produced_files'] = mock.Mock()
     for area in job['product_list']['product_list']['areas']:
         job['resampled_scenes'][area] = mock.Mock()
     return job


### PR DESCRIPTION
When saving multiple datasets to a single CF/NetCDF4 file using the syntax introduced in https://github.com/pytroll/trollflow2/pull/51 , I got random crashes resulting in `RuntimeError: NetCDF: Not a valid ID` within the XArray library. Some internet searching suggested that this is due to trying to use dimensions that have not yet been defined.

My solution to this is adding a config option that forces an eager saving instead of delaying the saving and calling `compute_writer_results()` afterwards. With this PR, I haven't seen this happen a single time over 50 consecutive runs.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
