### PR TITLE
Fix warning issued when multiple sensors are provided

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -421,9 +421,10 @@ def covers(job):
     end_time = scn_mda['end_time']
     sensor = scn_mda['sensor']
     if isinstance(sensor, (list, tuple, set)):
+        if len(sensor) > 1:
+            LOG.warning("Multiple sensors given, taking the first one for "
+                        "coverage calculations: %s", sensor)
         sensor = list(sensor)[0]
-        LOG.warning("Possibly many sensors given, taking only one for "
-                    "coverage calculations: %s", sensor)
 
     areas = list(product_list['product_list']['areas'].keys())
     for area in areas:

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1110,6 +1110,41 @@ class TestCovers(TestCase):
         covers(job)
         self.assertEqual(job, job_orig)
 
+    def test_covers_complains_when_multiple_sensors_are_provided(self):
+        """Test that the plugin complains when multiple sensors are provided."""
+        from trollflow2.plugins import covers
+
+        with mock.patch('trollflow2.plugins.get_scene_coverage') as get_scene_coverage, \
+                mock.patch('trollflow2.plugins.Pass'):
+            get_scene_coverage.return_value = 10.0
+            scn = _get_mocked_scene_with_properties()
+            job = {"product_list": self.product_list,
+                   "input_mda": {"platform_name": "platform",
+                                 "sensor": ["avhrr-3", "mhs"]},
+                   "scene": scn}
+            with self.assertLogs("trollflow2.plugins", logging.WARNING) as log:
+                covers(job)
+            assert len(log.output) == 1
+            assert ("Multiple sensors given, taking the first one for coverage calculations" in log.output[0])
+
+    def test_covers_does_not_complain_when_one_sensor_is_provided_as_a_sequence(self):
+        """Test that the plugin complains when multiple sensors are provided."""
+        from trollflow2.plugins import covers
+
+        with mock.patch('trollflow2.plugins.get_scene_coverage') as get_scene_coverage, \
+                mock.patch('trollflow2.plugins.Pass'):
+            get_scene_coverage.return_value = 10.0
+            scn = _get_mocked_scene_with_properties()
+            job = {"product_list": self.product_list,
+                   "input_mda": {"platform_name": "platform",
+                                 "sensor": ["avhrr-3"]},
+                   "scene": scn}
+            with self.assertLogs("trollflow2.plugins", logging.WARNING) as log:
+                covers(job)
+                logger = logging.getLogger("trollflow2.plugins")
+                logger.warning("Dummy warning")
+            assert len(log.output) == 1
+
     def test_metadata_is_read_from_scene(self):
         """Test that the scene and message metadata are merged correctly."""
         from trollflow2.plugins import covers


### PR DESCRIPTION
This PR removes a log warning when the sensor is provided as a sequence of only one element.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->

