### PR TITLE
Pop unknown keyword arguments in save_dataset

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -279,7 +279,7 @@ def save_datasets(job):
     Other arguments defined in the job list (either directly under
     ``product_list``, or under ``formats``) are passed on to the satpy writer.  The
     arguments ``use_tmp_file``, ``staging_zone``, ``output_dir``,
-    ``fname_pattern``, and ``dispatch`` are never passed to the reader.
+    ``fname_pattern``, and ``dispatch`` are never passed to the writer.
     """
     scns = job['resampled_scenes']
     objs = []

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -216,7 +216,7 @@ def save_dataset(scns, fmat, fmat_config, renames, compute=False):
         with prepared_filename(fmat, renames) as filename:
             res = fmat.get('resolution', DEFAULT)
             kwargs = fmat_config.copy()
-            # those keyword arguments are used by the trollflow2 plugin but not
+            # these keyword arguments are used by the trollflow2 plugin but not
             # by satpy writers
             for name in {"fname_pattern", "dispatch", "output_dir",
                          "use_tmp_file", "staging_zone"}:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -216,8 +216,11 @@ def save_dataset(scns, fmat, fmat_config, renames, compute=False):
         with prepared_filename(fmat, renames) as filename:
             res = fmat.get('resolution', DEFAULT)
             kwargs = fmat_config.copy()
-            kwargs.pop('fname_pattern', None)
-            kwargs.pop('dispatch', None)
+            # those keyword arguments are used by the trollflow2 plugin but not
+            # by satpy writers
+            for name in {"fname_pattern", "dispatch", "output_dir",
+                         "use_tmp_file", "staging_zone"}:
+                kwargs.pop(name, None)
             if isinstance(fmat['product'], (tuple, list, set)):
                 kwargs.pop('format')
                 dsids = []

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -275,6 +275,11 @@ def save_datasets(job):
     it is recommended to set ``use_tmp_file`` to `False` when using a
     ``staging_zone`` directory, such that the filename written to the
     headers remains meaningful.
+
+    Other arguments defined in the job list (either directly under
+    ``product_list``, or under ``formats``) are passed on to the satpy writer.  The
+    arguments ``use_tmp_file``, ``staging_zone``, ``output_dir``,
+    ``fname_pattern``, and ``dispatch`` are never passed to the reader.
     """
     scns = job['resampled_scenes']
     objs = []

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -572,7 +572,7 @@ class TestSaveDatasets(TestCase):
         product_list = {
             "fname_pattern": "name.tif",
             "use_tmp_file": True,
-            "staging_zone": "/tmp/a",
+            "staging_zone": "értékesítési szakember",
             "areas": {
                 "euron1": {
                     "products": {


### PR DESCRIPTION
When saving datasets, pop out all keyword arguments that are used by
the trollflow2 save_datasets plugin, but not by writers.

Add unit test to confirm this popping works.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #145 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
