### PR TITLE
Update native resampler handling

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -140,9 +140,9 @@ def _resample_null_area(product_list, scn, conf, area_conf):
     native = conf.get('resampler') == 'native'
     if use_coarsest_area is True:
         return scn.resample(scn.coarsest_area(), **area_conf)
-    elif use_finest_area is True:
+    if use_finest_area is True:
         return scn.resample(scn.finest_area(), **area_conf)
-    elif native:
+    if native:
         return scn.resample(resampler='native')
 
     # The composites need to be created for the saving to work

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -139,9 +139,9 @@ def _resample_null_area(product_list, scn, conf, area_conf):
     use_finest_area = _get_native_area(product_list, 'use_finest_area', legacy='use_max_area')
     native = conf.get('resampler') == 'native'
     if use_coarsest_area is True:
-        return scn.resample(scn.min_area(), **area_conf)
+        return scn.resample(scn.coarsest_area(), **area_conf)
     elif use_finest_area is True:
-        return scn.resample(scn.max_area(), **area_conf)
+        return scn.resample(scn.finest_area(), **area_conf)
     elif native:
         return scn.resample(resampler='native')
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -830,13 +830,13 @@ class TestResample(TestCase):
         scn.resample.return_value = "foo"
         product_list = self.product_list.copy()
         product_list['product_list']['areas']['None'] = product_list['product_list']['areas']['germ']
-        product_list['product_list']['areas']['None']['use_min_area'] = True
+        product_list['product_list']['areas']['None']['use_coarsest_area'] = True
         del product_list['product_list']['areas']['germ']
         del product_list['product_list']['areas']['omerc_bb']
         del product_list['product_list']['areas']['euron1']
         job = {"scene": scn, "product_list": product_list.copy()}
         resample(job)
-        self.assertTrue(mock.call(scn.min_area(),
+        self.assertTrue(mock.call(scn.coarsest_area(),
                                   radius_of_influence=None,
                                   resampler="nearest",
                                   reduce_data=True,
@@ -844,11 +844,11 @@ class TestResample(TestCase):
                                   mask_area=False,
                                   epsilon=0.0) in
                         scn.resample.mock_calls)
-        del product_list['product_list']['areas']['None']['use_min_area']
-        product_list['product_list']['areas']['None']['use_max_area'] = True
+        del product_list['product_list']['areas']['None']['use_coarsest_area']
+        product_list['product_list']['areas']['None']['use_finest_area'] = True
         job = {"scene": scn, "product_list": product_list.copy()}
         resample(job)
-        self.assertTrue(mock.call(scn.max_area(),
+        self.assertTrue(mock.call(scn.finest_area(),
                                   radius_of_influence=None,
                                   resampler="nearest",
                                   reduce_data=True,


### PR DESCRIPTION
Trollflow2 was still using the deprecated `scn.min_area()` and `scn.max_area()` methods for `null` areas. This PR switches over to the modern `scn.coarsest_area()` and `scn.finest_area()` and does some refactoring. Also the old config entries `use_min_area` and `use_max_area` are deprecated in favor of `use_coarsest_area` and `use_finest_area`.

 - [x] Tests updated  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
