### PR TITLE
Import hdf5plugin for JLS decompression support if available

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,25 +15,6 @@ Trollflow2 is an operational generation chain runner for Satpy.
 
 See the example playlist (``pl.yaml``) for inspiration.
 
-Installation
-------------
-
-Installing dependencies is simplest by using `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_::
-
-  mamba create -n trollflow2 satpy pyresample pyyaml dpath trollsift pyorbital
-
-For support of specific satellite data, see `Satpy documentation <https://satpy.readthedocs.io/en/stable/>`_ for the
-necessary packages that need to be installed.
-
-The Trollflow2 package isn't available via Conda, so it needs to be installed with ``pip``::
-
-  pip install trollflow2
-
-For decompression of MTG/FCI L1 files that have been compressed with CharLS compression ``hdf5plugin`` is needed::
-
-  mamba install hdf5plugin
-
-
 The launcher
 ------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,6 +15,25 @@ Trollflow2 is an operational generation chain runner for Satpy.
 
 See the example playlist (``pl.yaml``) for inspiration.
 
+Installation
+------------
+
+Installing dependencies is simplest by using `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_::
+
+  mamba create -n trollflow2 satpy pyresample pyyaml dpath trollsift pyorbital
+
+For support of specific satellite data, see `Satpy documentation <https://satpy.readthedocs.io/en/stable/>`_ for the
+necessary packages that need to be installed.
+
+The Trollflow2 package isn't available via Conda, so it needs to be installed with ``pip``::
+
+  pip install trollflow2
+
+For decompression of MTG/FCI L1 files that have been compressed with CharLS compression ``hdf5plugin`` is needed::
+
+  mamba install hdf5plugin
+
+
 The launcher
 ------------
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -28,6 +28,10 @@ from logging import getLogger
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlunsplit
 
+try:
+    import hdf5plugin  # noqa
+except ImportError:
+    pass
 import dpath.util
 import rasterio
 import dask

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -23,15 +23,13 @@
 
 import os
 import pathlib
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from logging import getLogger
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlunsplit
 
-try:
+with suppress(ImportError):
     import hdf5plugin  # noqa
-except ImportError:
-    pass
 import dpath.util
 import rasterio
 import dask


### PR DESCRIPTION
This PR brings support to decompression of MTG/FCI L1 files that have been compressed with JLS compression by trying to import `hdf5plugin` library.

Can't think of any unit tests for this, but I did run actual data through and decompression works after this minor change.

 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
