### PR TITLE
Adapt remote (fsspec) file reading for newer pytroll-collector changes

### DIFF
--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -39,7 +39,6 @@ from contextlib import suppress
 from datetime import datetime
 from logging import getLogger
 from queue import Empty
-from urllib.parse import urlparse
 
 import yaml
 from trollflow2.dict_tools import gen_dict_extract, plist_iter
@@ -266,7 +265,7 @@ def _extract_filenames(msg):
 
     If the message contains a `filesystem` item, use fsspec to decode it.
     """
-    filenames = [urlparse(uri).path for uri in gen_dict_extract(msg.data, 'uri')]
+    filenames = [uri.split("::")[0] for uri in gen_dict_extract(msg.data, 'uri')]
     filenames = _create_fs_file_instances(filenames, msg)
     return filenames
 

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -39,6 +39,7 @@ from contextlib import suppress
 from datetime import datetime
 from logging import getLogger
 from queue import Empty
+from urllib.parse import urlparse
 
 import yaml
 from trollflow2.dict_tools import gen_dict_extract, plist_iter
@@ -279,6 +280,8 @@ def _create_fs_file_instances(filenames, msg):
         import json
         filenames = [FSFile(filename, AbstractFileSystem.from_json(json.dumps(filesystem)))
                      for filename, filesystem in zip(filenames, filesystems)]
+    else:
+        filenames = [urlparse(uri).path for uri in gen_dict_extract(msg.data, 'uri')]
     return filenames
 
 

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -244,6 +244,35 @@ class TestMessageToJobs(TestCase):
             fsfile.assert_called_once_with(filename, abs_fs.from_json.return_value)
             abs_fs.from_json.assert_called_once_with(json.dumps(fs))
 
+    def test_message_to_jobs_with_fsspec_uri_without_fs_info(self):
+        """Test transforming a message containing a url without fsspec specification."""
+        with mock.patch.dict('sys.modules', {'fsspec': mock.MagicMock(),
+                                             'fsspec.spec': mock.MagicMock(),
+                                             'satpy': mock.MagicMock(),
+                                             'satpy.readers': mock.MagicMock(),
+                                             'satpy.resample': mock.MagicMock(),
+                                             'satpy.writers': mock.MagicMock(),
+                                             'satpy.dataset': mock.MagicMock(),
+                                             'satpy.version': mock.MagicMock()}):
+            from trollflow2.launcher import message_to_jobs
+
+            filename = "/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc"  # noqa
+            uri = "simplecache::ssh://someserver.example.com" + filename
+
+            msg_data = {"dataset": [{"uid": filename,
+                                     "uri": uri,
+                                     }]
+                        }
+
+            msg = mock.MagicMock()
+            msg.data = msg_data
+
+            prodlist = yaml.load(yaml_test_minimal, Loader=UnsafeLoader)
+            jobs = message_to_jobs(msg, prodlist)
+            extracted_filename = jobs[999]['input_filenames'][0]
+
+            assert extracted_filename == uri
+
     def test_message_to_jobs_non_fsspec_uri(self):
         """Test transforming a message containing a url without fsspec specification."""
         with mock.patch.dict('sys.modules', {'fsspec': mock.MagicMock(),
@@ -257,9 +286,10 @@ class TestMessageToJobs(TestCase):
             from trollflow2.launcher import message_to_jobs
 
             filename = "/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc"  # noqa
+            uri = "ssh://someserver.example.com" + filename
 
             msg_data = {"dataset": [{"uid": filename,
-                                     "uri": "ssh://someserver.example.com" + filename,
+                                     "uri": uri
                                      }]
                         }
 
@@ -270,7 +300,7 @@ class TestMessageToJobs(TestCase):
             jobs = message_to_jobs(msg, prodlist)
             extracted_filename = jobs[999]['input_filenames'][0]
 
-            assert extracted_filename == filename
+            assert extracted_filename == uri
 
 
 class TestRun(TestCase):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -220,7 +220,7 @@ class TestMessageToJobs(TestCase):
             from trollflow2.launcher import message_to_jobs
             import json
 
-            filename = "/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc"  # noqa
+            filename = "zip:///S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc"  # noqa
             fs = {"cls": "fsspec.implementations.zip.ZipFileSystem",
                   "protocol": "abstract",
                   "args": ["sentinel-s3-ol2wfr-zips/2020/12/10/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.zip"],  # noqa
@@ -228,8 +228,8 @@ class TestMessageToJobs(TestCase):
                   "target_options": {"anon": False,
                                      "client_kwargs": {"endpoint_url": "https://my.dismi.se"}}}
             msg_data = {"dataset": [{"filesystem": fs,
-                                     "uid": "zip:///S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.SEN3/Oa01_reflectance.nc::s3:///sentinel-s3-ol2wfr-zips/2020/12/10/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.zip",  # noqa
-                                     "uri": "zip://" + filename
+                                     "uid": filename,
+                                     "uri": filename + "::s3:///sentinel-s3-ol2wfr-zips/2020/12/10/S3A_OL_2_WFR____20201210T080758_20201210T080936_20201210T103707_0097_066_078_1980_MAR_O_NR_002.zip",  # noqa
                                      }]
                         }
 


### PR DESCRIPTION
Recent changes in the pytroll-collector package regarding formatting of message for remote filesystems require trollflow2 to adapt. This PR implements the adaptation.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->

