### PR TITLE
Add checking for incoming data age

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -283,6 +283,11 @@ discarded.  If the configured item isn't in the input message
 metadata, a warning is printed and the processing continues.  The best
 place for this plugin is before any data handling is done.
 
+In addition to equality checks, a negative integer ``start_time`` can be
+defined to denote the maximum age of the accepted data. For example
+``start_time: -60`` means that all data older than 60 minutes will be
+discarded.
+
 Options:
  - ``check_metadata: null`` - A dictionary of metadata names and list(s)
    of values that need to match.  By default (``null``) all scenes are

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -285,7 +285,7 @@ place for this plugin is before any data handling is done.
 
 In addition to equality checks, ``start_time`` can be used to check
 for data that are either too old or too new to be processed. To skip
-the maximum age (in minutes) of the accepted data, use a negative integer:
+accepted data older than a maximum age (in minutes) , use a negative integer:
 ``start_time: -60``. Similarly positive integer skips the processing of
 data newer than than the defined time.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -283,10 +283,11 @@ discarded.  If the configured item isn't in the input message
 metadata, a warning is printed and the processing continues.  The best
 place for this plugin is before any data handling is done.
 
-In addition to equality checks, a negative integer ``start_time`` can be
-defined to denote the maximum age of the accepted data. For example
-``start_time: -60`` means that all data older than 60 minutes will be
-discarded.
+In addition to equality checks, ``start_time`` can be used to check
+for data that are either too old or too new to be processed. To skip
+the maximum age (in minutes) of the accepted data, use a negative integer:
+``start_time: -60``. Similarly positive integer skips the processing of
+data newer than than the defined time.
 
 Options:
  - ``check_metadata: null`` - A dictionary of metadata names and list(s)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -291,7 +291,7 @@ In addition to equality checks, ``start_time`` can be used to check
 for data that are either too old or too new to be processed. To skip
 accepted data older than a maximum age (in minutes) , use a negative integer:
 ``start_time: -60``. Similarly positive integer skips the processing of
-data newer than than the defined time.
+data newer than the defined time.
 
 Options:
  - ``check_metadata: null`` - A dictionary of metadata names and list(s)

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -27,6 +27,7 @@ from contextlib import contextmanager
 from logging import getLogger
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlunsplit
+import datetime as dt
 
 import dpath.util
 import rasterio
@@ -521,7 +522,12 @@ def check_metadata(job):
             LOG.warning("Metadata item '%s' not in the input message.",
                         key)
             continue
-        if mda[key] not in val:
+        if key == 'start_time':
+            if mda[key] - dt.datetime.utcnow() < dt.timedelta(minutes=val):
+                raise AbortProcessing(
+                    "Data are older than the defined threshold. Skipping processing."
+                )
+        elif mda[key] not in val:
             raise AbortProcessing("Metadata '%s' item '%s' not in '%s'" %
                                   (key, mda[key], str(val)))
 

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -523,9 +523,11 @@ def check_metadata(job):
                         key)
             continue
         if key == 'start_time':
-            if mda[key] - dt.datetime.utcnow() < dt.timedelta(minutes=val):
+            time_diff = dt.datetime.utcnow() - mda[key]
+            if time_diff > abs(dt.timedelta(minutes=val)):
+                age = "older" if val < 0 else "newer"
                 raise AbortProcessing(
-                    "Data are older than the defined threshold. Skipping processing."
+                    f"Data are {age} than the defined threshold. Skipping processing."
                 )
         elif mda[key] not in val:
             raise AbortProcessing("Metadata '%s' item '%s' not in '%s'" %

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1392,6 +1392,18 @@ class TestCheckMetadata(TestCase):
             with self.assertRaises(AbortProcessing):
                 check_metadata(job)
 
+    def test_discard_new_data(self):
+        """Test that new data are discarded."""
+        from trollflow2.plugins import check_metadata
+        from trollflow2.plugins import AbortProcessing
+        with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
+            job = {'product_list': None, 'input_mda': {'start_time': dt.datetime.utcnow() - dt.timedelta(minutes=90)}}
+            get_config_value.return_value = {'start_time': +60}
+            with self.assertRaises(AbortProcessing):
+                check_metadata(job)
+            get_config_value.return_value = {'start_time': +100}
+            self.assertIsNone(check_metadata(job))
+
 
 class TestMetadataAlias(TestCase):
     """Test case for metadata alias."""

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1407,7 +1407,7 @@ class TestCheckMetadata(TestCase):
             with self.assertRaises(AbortProcessing):
                 check_metadata(job)
 
-    def test_old_data(self):
+    def test_discard_old_data(self):
         """Test that old data are discarded."""
         from trollflow2.plugins import check_metadata
         from trollflow2.plugins import AbortProcessing

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -566,6 +566,7 @@ class TestSaveDatasets(TestCase):
             compute_writer_results.assert_not_called()
 
     def test_pop_unknown_args(self):
+        """Test removing unknown arguments."""
         from trollflow2.plugins import save_datasets
         job = _create_job_for_save_datasets()
 
@@ -1374,6 +1375,20 @@ class TestCheckMetadata(TestCase):
             # Platform doesn't match -> abort
             get_config_value.return_value = {'sensor': ['foo'],
                                              'platform_name': ['not-bar']}
+            with self.assertRaises(AbortProcessing):
+                check_metadata(job)
+
+    def test_old_data(self):
+        """Test that old data are discarded."""
+        from trollflow2.plugins import check_metadata
+        from trollflow2.plugins import AbortProcessing
+        with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
+            get_config_value.return_value = None
+            job = {'product_list': None, 'input_mda': {'start_time': dt.datetime(2020, 3, 18)}}
+            self.assertIsNone(check_metadata(job))
+            get_config_value.return_value = {'start_time': -2e6}
+            self.assertIsNone(check_metadata(job))
+            get_config_value.return_value = {'start_time': -60}
             with self.assertRaises(AbortProcessing):
                 check_metadata(job)
 


### PR DESCRIPTION
With this PR it is possible to discard "too old" data before it is processed.

My use-case is the occasional data outages in Eumetacast, where the data are often sent late to make the data series intact. This causes the processing queue to stay full for hours (depending on the outage duration), and delays the processing of current data. With this feature it would be possible to discard the old data.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
