### PR TITLE
Do not crash when computing coverage of a dynamic area def

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -14,3 +14,4 @@ dependencies:
   - pyorbital
   - pip:
     - posttroll
+    - pytroll-schedule

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -501,7 +501,10 @@ def get_scene_coverage(platform_name, start_time, end_time, sensor, area_id):
     overpass = Pass(platform_name, start_time, end_time, instrument=sensor)
     area_def = get_area_def(area_id)
 
-    return 100 * overpass.area_coverage(area_def)
+    try:
+        return 100 * overpass.area_coverage(area_def)
+    except AttributeError:
+        return 100
 
 
 def check_metadata(job):


### PR DESCRIPTION
Computing the coverage of a dynamic area def does not work at the moment since the bbox can not be computed (understandably).
This fix gives a coverage of 100% for these types of areas.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->

