### PR TITLE
Pass arbitrary params to Scene.load

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -90,6 +90,10 @@ special keyword arguments:
    resampling.  This can save a lot of time if the same channels are
    used in several composites.  Default: ``True``.
 
+In addition, arbitrary keyword arguments can be configured with the
+``scene_load_kwargs`` parameter.  This is a dictionary with key/value
+pairs that will all be passed on every call to ``Scene.load``.
+
 Aggregate
 *********
 

--- a/examples/pl.yaml
+++ b/examples/pl.yaml
@@ -63,6 +63,9 @@ product_list: &product_list
   #   likely increase the required processing time.
   #   Issue on the XArray bug: https://github.com/pydata/xarray/issues/6300
   # eager_writing: True
+  # # pass extra keyword arguments to Scene.load
+  # scene_load_kwargs:
+  #   upper_right_corner: "NE"
 
   areas:
     omerc_bb:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -97,9 +97,10 @@ def load_composites(job):
             composites_by_res.setdefault(res, set()).add(flat_prod_cfg['product'])
     scn = job['scene']
     generate = job['product_list']['product_list'].get('delay_composites', True) is False
+    extra_args = job["product_list"]["product_list"].get("scene_load_kwargs", {})
     for resolution, composites in composites_by_res.items():
         LOG.info('Loading %s at resolution %s', str(composites), str(resolution))
-        scn.load(composites, resolution=resolution, generate=generate)
+        scn.load(composites, resolution=resolution, generate=generate, **extra_args)
     job['scene'] = scn
 
 

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -742,7 +742,6 @@ class TestLoadComposites(TestCase):
 
     def test_load_composites_with_custom_args(self):
         """Test loading with arbitrary additional arguments."""
-        """Test loading composites with different resolutions."""
         from trollflow2.plugins import load_composites, DEFAULT
         scn = _get_mocked_scene_with_properties()
         self.product_list['product_list']['scene_load_kwargs'] = {"upper_right_corner": "NE"}

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -740,6 +740,18 @@ class TestLoadComposites(TestCase):
         scn.load.assert_any_call({'cloudtype', 'ct', 'cloud_top_height'}, resolution=1000, generate=True)
         scn.load.assert_any_call({'cloud_top_height'}, resolution=500, generate=True)
 
+    def test_load_composites_with_custom_args(self):
+        """Test loading with arbitrary additional arguments."""
+        """Test loading composites with different resolutions."""
+        from trollflow2.plugins import load_composites, DEFAULT
+        scn = _get_mocked_scene_with_properties()
+        self.product_list['product_list']['scene_load_kwargs'] = {"upper_right_corner": "NE"}
+        job = {"product_list": self.product_list, "scene": scn}
+        load_composites(job)
+        scn.load.assert_called_with(
+                {'ct', 'cloudtype', 'cloud_top_height'},
+                resolution=DEFAULT, generate=False, upper_right_corner="NE")
+
 
 class TestAggregate(TestCase):
     """Test case for aggregating."""


### PR DESCRIPTION
Allow to configure arbitrary extra parameters to be passed to
Scene.load.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #153  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

