### PR TITLE
replace min/max area by finest/coarsest area

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -129,8 +129,8 @@ The default values are:
 
 For dynamic area definitions, which are not named, one can define the area as ``null`` and define one of
 
- - ``use_min_area: True`` or
- - ``use_max_area: True``
+ - ``use_coarsest_area: True`` or
+ - ``use_finest_area: True``
 
 The ``null`` area is also used when saving data without reprojecting.
 If the composites need matching of different resolutions, the native

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -129,18 +129,24 @@ def resample(job):
                                      conf)
         LOG.debug('Resampling to %s', str(area))
         if area == 'None':
-            minarea = get_config_value(product_list,
+            coarsest = (get_config_value(product_list,
+                                         '/product_list/areas/' + str(area),
+                                         'use_coarsest_area') or
+                        get_config_value(product_list,
+                                         '/product_list/areas/' + str(area),
+                                         'use_min_area'))
+            finest = (get_config_value(product_list,
                                        '/product_list/areas/' + str(area),
-                                       'use_min_area')
-            maxarea = get_config_value(product_list,
+                                       'use_finest_area') or
+                      get_config_value(product_list,
                                        '/product_list/areas/' + str(area),
-                                       'use_max_area')
+                                       'use_max_area'))
             native = conf.get('resampler') == 'native'
-            if minarea is True:
-                job['resampled_scenes'][area] = scn.resample(scn.min_area(),
+            if coarsest is True:
+                job['resampled_scenes'][area] = scn.resample(scn.coarsest_area(),
                                                              **area_conf)
-            elif maxarea is True:
-                job['resampled_scenes'][area] = scn.resample(scn.max_area(),
+            elif finest is True:
+                job['resampled_scenes'][area] = scn.resample(scn.finest_area(),
                                                              **area_conf)
             elif native:
                 job['resampled_scenes'][area] = scn.resample(resampler='native')

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -887,13 +887,13 @@ class TestResample(TestCase):
         scn.resample.return_value = "foo"
         product_list = self.product_list.copy()
         product_list['product_list']['areas']['None'] = product_list['product_list']['areas']['germ']
-        product_list['product_list']['areas']['None']['use_min_area'] = True
+        product_list['product_list']['areas']['None']['use_coarsest_area'] = True
         del product_list['product_list']['areas']['germ']
         del product_list['product_list']['areas']['omerc_bb']
         del product_list['product_list']['areas']['euron1']
         job = {"scene": scn, "product_list": product_list.copy()}
         resample(job)
-        self.assertTrue(mock.call(scn.min_area(),
+        self.assertTrue(mock.call(scn.coarsest_area(),
                                   radius_of_influence=None,
                                   resampler="nearest",
                                   reduce_data=True,
@@ -901,11 +901,11 @@ class TestResample(TestCase):
                                   mask_area=False,
                                   epsilon=0.0) in
                         scn.resample.mock_calls)
-        del product_list['product_list']['areas']['None']['use_min_area']
-        product_list['product_list']['areas']['None']['use_max_area'] = True
+        del product_list['product_list']['areas']['None']['use_coarsest_area']
+        product_list['product_list']['areas']['None']['use_finest_area'] = True
         job = {"scene": scn, "product_list": product_list.copy()}
         resample(job)
-        self.assertTrue(mock.call(scn.max_area(),
+        self.assertTrue(mock.call(scn.finest_area(),
                                   radius_of_influence=None,
                                   resampler="nearest",
                                   reduce_data=True,


### PR DESCRIPTION
In Satpy, get_min_area and get_max_area are deprecated.  They were still
being used in trollflow2.  Replace this by use_coarsest_area and
use_finest_area.  Update tests and documentation accordingly.  Keep the
old name for backward compatibility.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
