### PR TITLE
Handle setting subscriber nameserver to False

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -22,12 +22,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 """The satpy launcher."""
 
+import sys
+
 from trollflow2.launcher import launch
 
 
 def main():
     """Launch trollflow2."""
-    launch()
+    launch(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -22,67 +22,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 """The satpy launcher."""
 
-import argparse
-import logging
-
-from trollflow2.logging import logging_on
-from trollflow2.launcher import Runner
-from multiprocessing import Manager
-
-
-def parse_args():
-    """Parse commandline arguments."""
-    parser = argparse.ArgumentParser(
-        description='Launch trollflow2 processing with Satpy listening on the specified Posttroll topic(s)')
-    parser.add_argument("topic", nargs='*',
-                        help="Topic to listen to",
-                        type=str)
-    parser.add_argument("product_list",
-                        help="The yaml file with the product list",
-                        type=str)
-    parser.add_argument("-m", "--test_message",
-                        help="File path with the message used for testing offline. This implies threaded running.",
-                        type=str, required=False)
-    parser.add_argument("-t", "--threaded",
-                        help="Run the product generation in threads instead of processes.",
-                        action='store_true')
-
-    parser.add_argument("-c", "--log-config",
-                        help="Log config file (yaml) to use",
-                        type=str, required=False)
-    parser.add_argument('-n', "--nameserver", required=False, type=str,
-                        help="Nameserver to connect to", default='localhost')
-    parser.add_argument('-a', "--addresses", required=False, type=str,
-                        help=("Add direct TCP port connection.  Can be used several times: "
-                              "'-a tcp://127.0.0.1:12345 -a tcp://123.456.789.0:9013'"),
-                        action="append")
-
-    return parser.parse_args()
+from trollflow2.launcher import launch
 
 
 def main():
     """Launch trollflow2."""
-    args = vars(parse_args())
-
-    log_config = args.pop("log_config", None)
-    if log_config is not None:
-        with open(log_config) as fd:
-            import yaml
-            log_config = yaml.safe_load(fd.read())
-
-    logger = logging.getLogger("satpy_launcher")
-
-    log_queue = Manager().Queue()
-
-    with logging_on(log_queue, log_config):
-        logger.warning("Launching Satpy-based runner.")
-        product_list = args.pop("product_list")
-        test_message = args.pop("test_message")
-        threaded = args.pop("threaded")
-        connection_parameters = args
-
-        runner = Runner(product_list, log_queue, connection_parameters, test_message, threaded)
-        runner.run()
+    launch()
 
 
 if __name__ == "__main__":

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,6 +23,11 @@ The launcher
     :undoc-members:
     :show-inheritance:
 
+It is possible to disable Posttroll Nameserver usage for the incoming
+messages by starting ``satpy_launcher.py`` with command-line arguments
+``-n False -a tcp://<host>:<port>`` where the host and port point to a
+message publisher. Multiple publisher addresses can be given by supplying
+them with additional ``-a`` switches.
 
 Plugins
 -------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to Trollflow2's documentation!
 
 Trollflow2 is an operational generation chain runner for Satpy.
 
-See the example playlist (``pl.yaml``) for inspiration.
+See the bottom of this page and the example playlist (``pl.yaml``) for inspiration.
 
 The launcher
 ------------

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -442,9 +442,9 @@ def sendmail(config, trace):
     pid.terminate()
 
 
-def launch():
+def launch(args_in):
     """Launch the processing."""
-    args = vars(parse_args())
+    args = parse_args(args_in)
 
     log_config = args.pop("log_config", None)
     if log_config is not None:
@@ -466,7 +466,7 @@ def launch():
         runner.run()
 
 
-def parse_args():
+def parse_args(args_in):
     """Parse commandline arguments."""
     parser = argparse.ArgumentParser(
         description='Launch trollflow2 processing with Satpy listening on the specified Posttroll topic(s)')
@@ -493,4 +493,8 @@ def parse_args():
                               "'-a tcp://127.0.0.1:12345 -a tcp://123.456.789.0:9013'"),
                         action="append")
 
-    return parser.parse_args()
+    args = vars(parser.parse_args(args_in))
+    if args['nameserver'].lower() in ('false', 'off', '0'):
+        args['nameserver'] = False
+
+    return args

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -456,7 +456,7 @@ def launch(args_in):
     log_queue = Manager().Queue()
 
     with logging_on(log_queue, log_config):
-        logger.warning("Launching Satpy-based runner.")
+        logger.info("Launching Satpy-based runner.")
         product_list = args.pop("product_list")
         test_message = args.pop("test_message")
         threaded = args.pop("threaded")

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -487,7 +487,7 @@ def parse_args(args_in):
                         help="Log config file (yaml) to use",
                         type=str, required=False)
     parser.add_argument('-n', "--nameserver", required=False, type=str,
-                        help="Nameserver to connect to", default='localhost')
+                        help="Nameserver to connect to. Disable by setting to False", default='localhost')
     parser.add_argument('-a', "--addresses", required=False, type=str,
                         help=("Add direct TCP port connection.  Can be used several times: "
                               "'-a tcp://127.0.0.1:12345 -a tcp://123.456.789.0:9013'"),

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -26,7 +26,7 @@ This delegate the actual running of the plugins to a subprocess to avoid any
 memory buildup.
 """
 
-
+import argparse
 import ast
 import copy
 import gc
@@ -37,23 +37,25 @@ import traceback
 from collections import OrderedDict
 from contextlib import suppress
 from datetime import datetime
-from logging import getLogger
+import logging
 from queue import Empty
+from multiprocessing import Manager
 
 import yaml
-from trollflow2.dict_tools import gen_dict_extract, plist_iter
-from trollflow2.logging import setup_queued_logging
-from trollflow2.plugins import AbortProcessing
+from yaml import UnsafeLoader, SafeLoader, BaseLoader
 
 try:
     from posttroll.listener import ListenerContainer
 except ImportError:
     ListenerContainer = None
 
-from yaml import UnsafeLoader, SafeLoader, BaseLoader
+from trollflow2.dict_tools import gen_dict_extract, plist_iter
+from trollflow2.logging import logging_on
+from trollflow2.logging import setup_queued_logging
+from trollflow2.plugins import AbortProcessing
 
 
-LOG = getLogger(__name__)
+LOG = logging.getLogger(__name__)
 DEFAULT_PRIORITY = 999
 
 
@@ -438,3 +440,57 @@ def sendmail(config, trace):
     pid = Popen([sendmail, "-t", "-oi"], stdin=PIPE)
     pid.communicate(msg.as_bytes())
     pid.terminate()
+
+
+def launch():
+    """Launch the processing."""
+    args = vars(parse_args())
+
+    log_config = args.pop("log_config", None)
+    if log_config is not None:
+        with open(log_config) as fd:
+            log_config = yaml.safe_load(fd.read())
+
+    logger = logging.getLogger("satpy_launcher")
+
+    log_queue = Manager().Queue()
+
+    with logging_on(log_queue, log_config):
+        logger.warning("Launching Satpy-based runner.")
+        product_list = args.pop("product_list")
+        test_message = args.pop("test_message")
+        threaded = args.pop("threaded")
+        connection_parameters = args
+
+        runner = Runner(product_list, log_queue, connection_parameters, test_message, threaded)
+        runner.run()
+
+
+def parse_args():
+    """Parse commandline arguments."""
+    parser = argparse.ArgumentParser(
+        description='Launch trollflow2 processing with Satpy listening on the specified Posttroll topic(s)')
+    parser.add_argument("topic", nargs='*',
+                        help="Topic to listen to",
+                        type=str)
+    parser.add_argument("product_list",
+                        help="The yaml file with the product list",
+                        type=str)
+    parser.add_argument("-m", "--test_message",
+                        help="File path with the message used for testing offline. This implies threaded running.",
+                        type=str, required=False)
+    parser.add_argument("-t", "--threaded",
+                        help="Run the product generation in threads instead of processes.",
+                        action='store_true')
+
+    parser.add_argument("-c", "--log-config",
+                        help="Log config file (yaml) to use",
+                        type=str, required=False)
+    parser.add_argument('-n', "--nameserver", required=False, type=str,
+                        help="Nameserver to connect to", default='localhost')
+    parser.add_argument('-a', "--addresses", required=False, type=str,
+                        help=("Add direct TCP port connection.  Can be used several times: "
+                              "'-a tcp://127.0.0.1:12345 -a tcp://123.456.789.0:9013'"),
+                        action="append")
+
+    return parser.parse_args()

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -446,10 +446,7 @@ def launch(args_in):
     """Launch the processing."""
     args = parse_args(args_in)
 
-    log_config = args.pop("log_config", None)
-    if log_config is not None:
-        with open(log_config) as fd:
-            log_config = yaml.safe_load(fd.read())
+    log_config = _read_log_config(args)
 
     logger = logging.getLogger("satpy_launcher")
 
@@ -464,6 +461,14 @@ def launch(args_in):
 
         runner = Runner(product_list, log_queue, connection_parameters, test_message, threaded)
         runner.run()
+
+
+def _read_log_config(args):
+    log_config = args.pop("log_config", None)
+    if log_config is not None:
+        with open(log_config) as fd:
+            log_config = yaml.safe_load(fd.read())
+    return log_config
 
 
 def parse_args(args_in):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -774,5 +774,13 @@ def test_check_results(tmp_path, caplog):
     assert "Process killed with signal 1" in caplog.text
 
 
+def test_argparse_nameserver_is_none():
+    """Test that '-n false' is sets nameserver as False."""
+    from trollflow2.launcher import parse_args
+
+    res = parse_args(['-n', 'false', 'product_list.yaml'])
+    assert res['nameserver'] is False
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -782,5 +782,19 @@ def test_argparse_nameserver_is_none():
     assert res['nameserver'] is False
 
 
+def test_launch():
+    """Test launcher.launch()."""
+    with mock.patch("trollflow2.launcher.Runner") as Runner:
+        from trollflow2.launcher import launch
+
+        args_in = ['-n', 'localhost', '-a', 'localhost:12345', 'product_list.yaml']
+        launch(args_in)
+        # See that the commandline arguments are passed to Runner
+        assert "'nameserver': 'localhost'" in str(Runner.mock_calls)
+        assert "'addresses': ['localhost:12345']" in str(Runner.mock_calls)
+        assert "product_list.yaml" in str(Runner.mock_calls)
+        Runner.return_value.run.assert_called_once()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It wasn't possible to disable the subscriber nameserver to `False`. With this PR, the argument parsing takes care of this. Also, the argument parsing and launching of the `Runner` have now been moved to `trollflow2.launcher` so we could add tests for them.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
