### PR TITLE
Make it possible to disable nameserver in FilePublisher

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -175,7 +175,9 @@ The available options, with the default values, are:
    port is selected.
  - ``nameservers: null`` - a list of nameservers to connect to.  Defining
    any nameserver turns multicast messaging off.  Default to the
-   nameserver on localhost and use multicast
+   nameserver on localhost and use multicast.  The nameserver can be
+   completely switched of by defining it as ``false`` and giving a valid
+   ``port`` number.
 
 These options are given in the list of workers as a dictionary
 argument to the ``FilePublisher`` class.

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -35,7 +35,7 @@ import dpath.util
 import rasterio
 import dask
 from posttroll.message import Message
-from posttroll.publisher import Publisher, NoisyPublisher
+from posttroll.publisher import create_publisher_from_dict_config
 from pyorbital.astronomy import sun_zenith_angle
 from pyresample.boundary import AreaDefBoundary, Boundary
 from pyresample.area_config import AreaNotFound
@@ -330,12 +330,14 @@ class FilePublisher:
         LOG.debug('Starting publisher')
         self.port = kwargs.get('port', 0)
         self.nameservers = kwargs.get('nameservers', "")
-        if self.nameservers is None:
-            self.pub = Publisher("tcp://*:" + str(self.port), "l2processor")
-        else:
-            self.pub = NoisyPublisher('l2processor', port=self.port,
-                                      nameservers=self.nameservers)
-            self.pub.start()
+        self._pub_starter = create_publisher_from_dict_config(
+            {
+                'port': self.port,
+                'nameservers': self.nameservers,
+                'name': 'l2processor',
+            }
+        )
+        self.pub = self._pub_starter.start()
 
     @staticmethod
     def create_message(fmat, mda):

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1781,13 +1781,13 @@ class TestFilePublisher(TestCase):
 
         return topics
 
-    def test_filepublisher_kwargs(self):
-        """Test filepublisher keyword argument usage."""
-        from yaml import UnsafeLoader
+    def test_filepublisher_kwargs_direct_instance_defaults(self):
+        """Test filepublisher keyword argument usage.
 
+        Direct instantation, default settings.
+        """
         from trollflow2.plugins import FilePublisher
 
-        # Direct instantiation
         with mock.patch('trollflow2.plugins.Message'), \
                 mock.patch.multiple(
                     'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
@@ -1802,24 +1802,49 @@ class TestFilePublisher(TestCase):
             Publisher.assert_not_called()
             assert pub.port == 0
             assert pub.nameservers == ""
+
+    def test_filepublisher_kwargs_direct_instance_user_settings(self):
+        """Test filepublisher keyword argument usage.
+
+        Direct instantation, user settings.
+        """
+        from trollflow2.plugins import FilePublisher
+
+        with mock.patch('trollflow2.plugins.Message'), \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
+            NoisyPublisher = mocks['NoisyPublisher']
+
             pub = FilePublisher(port=40000, nameservers=['localhost'])
             assert mock.call('l2processor', port=40000, aliases=None, broadcast_interval=2,
                              nameservers=['localhost'], min_port=None, max_port=None) in NoisyPublisher.mock_calls
             assert pub.port == 40000
             assert pub.nameservers == ['localhost']
 
-        # Direct instantiation with nameservers set to None, which should use Publisher instead of NoisyPublisher
+    def test_filepublisher_kwargs_direct_instance_no_nameserver(self):
+        """Test filepublisher keyword argument usage.
+
+        Direct instantation, nameserver switched off.
+        """
+        from trollflow2.plugins import FilePublisher
+
         with mock.patch('trollflow2.plugins.Message'), \
                 mock.patch.multiple(
                     'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
             NoisyPublisher = mocks['NoisyPublisher']
             Publisher = mocks['Publisher']
 
-            pub = FilePublisher(port=40000, nameservers=False)
+            _ = FilePublisher(port=40000, nameservers=False)
             NoisyPublisher.assert_not_called()
             Publisher.assert_called_once_with('tcp://*:40000', name='l2processor', min_port=None, max_port=None)
 
-        # Instantiate via loading YAML
+    def test_filepublisher_kwargs(self):
+        """Test filepublisher keyword argument usage.
+
+        User settings and FilePublisher instantiated from YAML.
+        """
+        from yaml import UnsafeLoader
+
         with mock.patch('trollflow2.plugins.Message'), \
                 mock.patch.multiple(
                     'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1638,14 +1638,14 @@ class TestFilePublisher(TestCase):
     def test_filepublisher_is_started(self):
         """Test that the filepublisher is started."""
         from trollflow2.plugins import FilePublisher
-        with mock.patch('trollflow2.plugins.NoisyPublisher'):
-            pub = FilePublisher()
-            pub.pub.start.assert_called_once()
+        with mock.patch('posttroll.publisher.NoisyPublisher') as NoisyPublisher:
+            _ = FilePublisher()
+            NoisyPublisher.return_value.start.assert_called_once()
 
     def test_filepublisher_is_stopped_on_exit(self):
         """Test that the filepublisher is stopped on exit."""
         from trollflow2.plugins import FilePublisher
-        with mock.patch('trollflow2.plugins.NoisyPublisher'):
+        with mock.patch('posttroll.publisher.NoisyPublisher'):
             pub = FilePublisher()
             pub.__del__()
             pub.pub.stop.assert_called()
@@ -1664,9 +1664,10 @@ class TestFilePublisher(TestCase):
                'input_mda': self.input_mda,
                'resampled_scenes': dict(euron1=scn_euron1)}
 
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
-            message = mocks['Message']
+        with mock.patch('trollflow2.plugins.Message') as Message, \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT):
+            message = Message
 
             pub = FilePublisher()
             product_list = self.product_list.copy()
@@ -1699,9 +1700,10 @@ class TestFilePublisher(TestCase):
                'input_mda': self.input_mda,
                'resampled_scenes': dict(euron1=scn_euron1)}
 
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
-            message = mocks['Message']
+        with mock.patch('trollflow2.plugins.Message') as Message, \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT):
+            message = Message
 
             pub, topics = self._run_publisher_on_job(job)
             message.assert_called()
@@ -1724,7 +1726,7 @@ class TestFilePublisher(TestCase):
         job = {"scene": scn, "product_list": self.product_list, 'input_mda': self.input_mda,
                'resampled_scenes': dict(euron1=Scene(), germ=Scene())}
 
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher'):
+        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('posttroll.publisher.NoisyPublisher'):
             self._run_publisher_on_job(job)
             message.assert_not_called()
 
@@ -1740,7 +1742,7 @@ class TestFilePublisher(TestCase):
         job = {"scene": scn, "product_list": self.product_list, 'input_mda': self.input_mda,
                'resampled_scenes': {'None': resampled_scene}}
 
-        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('trollflow2.plugins.NoisyPublisher'):
+        with mock.patch('trollflow2.plugins.Message') as message, mock.patch('posttroll.publisher.NoisyPublisher'):
             self._run_publisher_on_job(job)
             assert message.call_args_list[-1][0][2]['product'] == (
                 'chl_nn', 'chl_oc4me', 'trsp', 'tsm_nn', 'iop_nn', 'mask', 'latitude', 'longitude')
@@ -1786,45 +1788,50 @@ class TestFilePublisher(TestCase):
         from trollflow2.plugins import FilePublisher
 
         # Direct instantiation
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
+        with mock.patch('trollflow2.plugins.Message'), \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
             NoisyPublisher = mocks['NoisyPublisher']
             Publisher = mocks['Publisher']
 
             pub = FilePublisher()
-            pub.pub.start.assert_called_once()
-            assert mock.call('l2processor', port=0, nameservers="") in NoisyPublisher.mock_calls
+            NoisyPublisher.assert_called_once()
+            assert pub.pub is NoisyPublisher.return_value.start.return_value
+            assert mock.call('l2processor', port=0, aliases=None, broadcast_interval=2,
+                             nameservers="", min_port=None, max_port=None) in NoisyPublisher.mock_calls
             Publisher.assert_not_called()
             assert pub.port == 0
             assert pub.nameservers == ""
             pub = FilePublisher(port=40000, nameservers=['localhost'])
-            assert mock.call('l2processor', port=40000,
-                             nameservers=['localhost']) in NoisyPublisher.mock_calls
+            assert mock.call('l2processor', port=40000, aliases=None, broadcast_interval=2,
+                             nameservers=['localhost'], min_port=None, max_port=None) in NoisyPublisher.mock_calls
             assert pub.port == 40000
             assert pub.nameservers == ['localhost']
-            assert len(pub.pub.start.mock_calls) == 2
 
         # Direct instantiation with nameservers set to None, which should use Publisher instead of NoisyPublisher
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
+        with mock.patch('trollflow2.plugins.Message'), \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
             NoisyPublisher = mocks['NoisyPublisher']
             Publisher = mocks['Publisher']
 
-            pub = FilePublisher(port=40000, nameservers=None)
+            pub = FilePublisher(port=40000, nameservers=False)
             NoisyPublisher.assert_not_called()
-            Publisher.assert_called_once_with('tcp://*:40000', 'l2processor')
+            Publisher.assert_called_once_with('tcp://*:40000', name='l2processor', min_port=None, max_port=None)
 
         # Instantiate via loading YAML
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
+        with mock.patch('trollflow2.plugins.Message'), \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
             NoisyPublisher = mocks['NoisyPublisher']
             Publisher = mocks['Publisher']
 
             fpub = read_config(raw_string=YAML_FILE_PUBLISHER, Loader=UnsafeLoader)
-            assert mock.call('l2processor', port=40002,
-                             nameservers=['localhost']) in NoisyPublisher.mock_calls
+            assert mock.call('l2processor', port=40002, aliases=None, broadcast_interval=2,
+                             nameservers=['localhost'], min_port=None, max_port=None) in NoisyPublisher.mock_calls
             Publisher.assert_not_called()
-            fpub.pub.start.assert_called_once()
+            assert fpub.pub is NoisyPublisher.return_value.start.return_value
+            NoisyPublisher.assert_called_once()
             assert fpub.port == 40002
             assert fpub.nameservers == ['localhost']
 
@@ -1842,9 +1849,10 @@ class TestFilePublisher(TestCase):
                'input_mda': self.input_mda,
                'resampled_scenes': dict(euron1=scn)}
 
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
-            message = mocks['Message']
+        with mock.patch('trollflow2.plugins.Message') as Message, \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT):
+            message = Message
 
             pub = FilePublisher()
             pub(job)
@@ -1869,8 +1877,9 @@ class TestFilePublisher(TestCase):
         """Test deleting the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
+        with mock.patch('trollflow2.plugins.Message'), \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
             NoisyPublisher = mocks['NoisyPublisher']
 
             NoisyPublisher.return_value = nb_
@@ -1880,16 +1889,17 @@ class TestFilePublisher(TestCase):
                    'resampled_scenes': {}}
             pub(job)
 
-        nb_.stop.assert_not_called()
+        nb_.start.return_value.stop.assert_not_called()
         del pub
-        nb_.stop.assert_called_once()
+        nb_.start.return_value.stop.assert_called_once()
 
     def test_stopping(self):
         """Test stopping the publisher."""
         from trollflow2.plugins import FilePublisher
         nb_ = mock.MagicMock()
-        with mock.patch.multiple('trollflow2.plugins', Message=mock.DEFAULT,
-                                 NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
+        with mock.patch('trollflow2.plugins.Message'), \
+                mock.patch.multiple(
+                    'posttroll.publisher', NoisyPublisher=mock.DEFAULT, Publisher=mock.DEFAULT) as mocks:
             NoisyPublisher = mocks['NoisyPublisher']
 
             NoisyPublisher.return_value = nb_
@@ -1899,9 +1909,9 @@ class TestFilePublisher(TestCase):
                    'resampled_scenes': {}}
             pub(job)
 
-        nb_.stop.assert_not_called()
+        nb_.start.return_value.stop.assert_not_called()
         pub.stop()
-        nb_.stop.assert_called_once()
+        nb_.start.return_value.stop.assert_called_once()
 
 
 class FakeScene(dict):


### PR DESCRIPTION
This PR switches the `FilePublisher` plugin to use `create_publisher_from_dict_config()` from Posttroll.

The undocumented feature of turning `nameserver` usage off uses now the same principles that Posttroll:
- use `nameservers: False`
- set `port` to non-zero numeric value

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
