### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         experimental: [false]
         include:
-          - python-version: "3.10"
+          - python-version: "3.11"
             os: "ubuntu-latest"
             experimental: true
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # trollflow2
 Next generation trollflow
 
-Trollflow2 supports only Python 3.4 and newer.
+Trollflow2 supports only Python 3.9 and newer in Linux. OS X might work, but the tests are not run on it.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,8 +16,9 @@ Welcome to Trollflow2's documentation!
    logging
 
 
-Trollflow2 is an operational generation chain runner for Satpy.
+Trollflow2 is an operational generation chain runner for Satpy in Linux.
 
+Official support for OS X was dropped in v0.15, but it might still work.
 
 Indices and tables
 ==================

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name=NAME,
       zip_safe=False,
       install_requires=install_requires,
       tests_require=['pytest', 'mock', 'rasterio'],
-      python_requires='>=3.4',
+      python_requires='>=3.9',
       test_suite='trollflow2.tests.suite',
       use_scm_version=True
       )

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -26,7 +26,6 @@ import datetime
 import logging
 import os
 import queue
-import sys
 import time
 import unittest
 from contextlib import contextmanager
@@ -632,8 +631,6 @@ class TestProcess(TestCase):
         with pytest.raises(YAMLError):
             process("msg", "prod_list", self.queue)
 
-    @pytest.mark.skipif(sys.platform != "linux",
-                        reason="Timeout only supported on Linux")
     def test_timeout_in_running_job(self):
         """Test timeout in running job."""
         def wait(job):

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -22,7 +22,6 @@
 """Tests for the logging utilities."""
 
 import logging
-import sys
 import time
 from unittest import mock
 
@@ -147,8 +146,6 @@ def fun(loggers):
         logger.warning(f"{log_name} warning")
 
 
-@pytest.mark.skipif(sys.platform != "linux",
-                    reason="Logging from a subprocess seems to work only on Linux")
 def test_logging_works_in_subprocess_not_double(tmp_path):
     """Test that the logs get to a file, even from a subprocess, without duplicate lines."""
     logfile = tmp_path / "mylog"


### PR DESCRIPTION
This PR drops Python 3.8 support from Trollflow2.

The CI is adjusted to test with Python 3.9, 3.10 and 3.11.

 - [ ] Tests passed <!-- for all non-documentation changes -->
