### PR TITLE
Profile CLI run through dask

### DIFF
--- a/trollflow2/cli.py
+++ b/trollflow2/cli.py
@@ -56,11 +56,11 @@ def cli(args=None):
         if args.dask_profiler:
             profs.append(stack.enter_context(dask.diagnostics.Profiler()))
             if args.dask_resource_profiler:
-                profs.append(stack.enter_context(dask.diagnostics.ResourceProfiler(dt=args.dask_resource_profiles)))
+                profs.append(stack.enter_context(dask.diagnostics.ResourceProfiler(dt=args.dask_resource_profiler)))
         process_files(args.files, json.loads(args.metadata), args.product_list, produced_files)
-        if args.dask_profiler:
-            dask.diagnostics.visualize(
-                    [profs], show=False, save=True, filename=args.dask_profiler)
+    if args.dask_profiler:
+        dask.diagnostics.visualize(
+            profs, show=False, save=True, filename=args.dask_profiler)
 
 
 def _read_log_config(args):


### PR DESCRIPTION
For the CLI added in #184, add an option to profile the results using dask.diagnostics and visualize the results as a bokeh plot.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
