### PR TITLE
Fix logging to handler config without loggers

### DIFF
--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -129,6 +129,8 @@ def remove_handlers_from_config(config):
     config.pop("handlers", None)
     for logger in config.get("loggers", []):
         config["loggers"][logger].pop("handlers", None)
+    if config.get("root", None):
+        config["root"].pop("handlers", None)
 
 
 def queued_logging(func):

--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -127,7 +127,7 @@ def setup_queued_logging(log_queue, config=None):
 def remove_handlers_from_config(config):
     """Remove handlers from config."""
     config.pop("handlers", None)
-    for logger in config["loggers"]:
+    for logger in config.get("loggers", []):
         config["loggers"][logger].pop("handlers", None)
 
 

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -207,10 +207,18 @@ def test_logging_config_without_loggers(tmp_path):
     assert "root warning" in file_contents
 
 
-def test_default_logging_config_works_with_subprocesses():
+def test_default_logging_config_works_with_subprocesses(capsys):
     """Test that the default log config works."""
     LOG_CONFIG_TO_FILE = DEFAULT_LOG_CONFIG
-
+    captured = capsys.readouterr()
     with logging_on(LOG_CONFIG_TO_FILE):
         proc = run_subprocess(["foo1", "foo2"])
+    captured = capsys.readouterr()
     assert proc.exitcode == 0
+    err = captured.err
+    assert not duplicate_lines(err)
+    assert "root debug" in err
+    assert "root info" in err
+    assert "root warning" in err
+    assert "foo1 debug" in err
+    assert "foo2 debug" in err

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -185,7 +185,7 @@ def duplicate_lines(contents):
 
 
 def test_logging_config_without_loggers(tmp_path):
-    """Test that the logs get to a file, even from a subprocess, without duplicate lines."""
+    """Test that the log configs without loggers work."""
     logfile = tmp_path / "mylog"
     LOG_CONFIG_TO_FILE = {'version': 1,
                           'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -27,8 +27,8 @@ from unittest import mock
 
 import pytest
 
-from trollflow2.logging import (create_logged_process, logging_on,
-                                queued_logging)
+from trollflow2.logging import (DEFAULT_LOG_CONFIG, create_logged_process,
+                                logging_on, queued_logging)
 
 
 def test_queued_logging_has_a_listener():
@@ -129,6 +129,7 @@ def run_subprocess(loggers):
     proc = create_logged_process(target=fun, args=(loggers,))
     proc.start()
     proc.join()
+    return proc
 
 
 @queued_logging
@@ -192,7 +193,7 @@ def test_logging_config_without_loggers(tmp_path):
                           'handlers': {'file': {'class': 'logging.FileHandler',
                                                 'filename': logfile,
                                                 'formatter': 'simple'}},
-                          "root": {"level": "DEBUG"}
+                          "root": {"level": "DEBUG", "handlers": ["file"]}
                           }
 
     with logging_on(LOG_CONFIG_TO_FILE):
@@ -201,5 +202,15 @@ def test_logging_config_without_loggers(tmp_path):
         file_contents = fd.read()
 
     assert not duplicate_lines(file_contents)
-    assert "root debug" not in file_contents
-    assert "root info" not in file_contents
+    assert "root debug" in file_contents
+    assert "root info" in file_contents
+    assert "root warning" in file_contents
+
+
+def test_default_logging_config_works_with_subprocesses():
+    """Test that the default log config works."""
+    LOG_CONFIG_TO_FILE = DEFAULT_LOG_CONFIG
+
+    with logging_on(LOG_CONFIG_TO_FILE):
+        proc = run_subprocess(["foo1", "foo2"])
+    assert proc.exitcode == 0

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1552,9 +1552,9 @@ class TestCheckMetadata(TestCase):
         with mock.patch('trollflow2.plugins.get_config_value') as get_config_value:
             get_config_value.return_value = None
             job = {'product_list': None, 'input_mda': {'start_time': dt.datetime(2020, 3, 18)}}
-            self.assertIsNone(check_metadata(job))
-            get_config_value.return_value = {'start_time': -2e6}
-            self.assertIsNone(check_metadata(job))
+            assert check_metadata(job) is None
+            get_config_value.return_value = {'start_time': -20e6}
+            assert check_metadata(job) is None
             get_config_value.return_value = {'start_time': -60}
             with self.assertRaises(AbortProcessing):
                 check_metadata(job)


### PR DESCRIPTION
This PR allows trollflow2 to accept log configs without loggers.

 - [x] Closes #197  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Closes #192 
 - [x] Closes #183 
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->

