### PR TITLE
Add plugins for fsspec caching and cache cleaning

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -1138,3 +1138,12 @@ def use_fsspec_cache(job):
         open_files = fsspec.open_files(cached_filenames)
     fs_files = [FSFile(open_file) for open_file in open_files]
     job["input_filenames"] = fs_files
+
+
+def clear_fsspec_cache(job):
+    """Clear all files in fsspec cache directory."""
+    filenames = job["input_filenames"]
+
+    for f in filenames:
+        if hasattr(f, "_fs"):
+            f._fs.clear_cache()

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -1114,3 +1114,15 @@ def callback_close(obj, targs, job, fmat_config):
         for targ in targs:
             targ.close()
     return obj
+
+
+def use_fsspec_cache(job):
+    """Use the caching from fsspec for (remote) files."""
+    import fsspec
+    from satpy.readers import FSFile
+
+    cache = job["product_list"]["fsspec_cache"]
+    filenames = job["input_filenames"]
+    open_files = fsspec.open_files([f"{cache}::{f}" for f in filenames])
+    fs_files = [FSFile(open_file) for open_file in open_files]
+    job["input_filenames"] = fs_files

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -1122,7 +1122,19 @@ def use_fsspec_cache(job):
     from satpy.readers import FSFile
 
     cache = job["product_list"]["fsspec_cache"]
+    cache_dir = job["product_list"].get("fsspec_cache_dir")
     filenames = job["input_filenames"]
-    open_files = fsspec.open_files([f"{cache}::{f}" for f in filenames])
+    cached_filenames = [f"{cache}::{f}" for f in filenames]
+    if cache == "blockcache":
+        open_files = fsspec.open_files(cached_filenames,
+                                       blockcache={"cache_storage": cache_dir})
+    elif cache == "filecache":
+        open_files = fsspec.open_files(cached_filenames,
+                                       filecache={"cache_storage": cache_dir})
+    elif cache == "simplecache":
+        open_files = fsspec.open_files(cached_filenames,
+                                       simplecache={"cache_storage": cache_dir})
+    else:
+        open_files = fsspec.open_files(cached_filenames)
     fs_files = [FSFile(open_file) for open_file in open_files]
     job["input_filenames"] = fs_files

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -2307,8 +2307,8 @@ def local_test_file(tmp_path):
     return fname
 
 
-def test_fsspec_cache_method_file(local_test_file):
-    """Test that the configured cache method is applied to the URI of a single file."""
+def test_use_fsspec_cache(local_test_file):
+    """Test that the configured cache method is applied to the given input files."""
     import fsspec
     from satpy.readers import FSFile
 


### PR DESCRIPTION
This PR adds the possibility to do caching with `fsspec`. Mostly useful for remotely read data that has a complicated structure which slows down the reading such as FCI L1c in S3 storage. Additional plugin is available for cleaning the cache.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
