### PR TITLE
Move import to be dask-dist friendly

### DIFF
--- a/bin/satpy_launcher.py
+++ b/bin/satpy_launcher.py
@@ -24,11 +24,10 @@
 
 import sys
 
-from trollflow2.launcher import launch
-
 
 def main():
     """Launch trollflow2."""
+    from trollflow2.launcher import launch
     launch(sys.argv[1:])
 
 


### PR DESCRIPTION
Make trollflow2 more multiprocessing / dask-distributed friendly. Move the launcher import in satpy_launcher.py within the main function, so that it only gets executed in the primary process. The call to `Manager()` in `trollflow2.__init__.py` was causing attempts to use trollflow2 with dask distributed to fail with a RuntimeError.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

I don't know how to add a unit test for this.