### PR TITLE
Added crop functionality to trollflow2

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -170,6 +170,25 @@ def resample(job):
             logger.debug("area: %s, area_conf: %s", area, str(area_conf))
             job['resampled_scenes'][area] = scn.resample(area, **area_conf)
 
+def crop(job):
+    """Crop the scene to some areas. Cropping to the llbox and xybox are not supported jet."""
+
+    product_list = job["product_list"]
+    conf = _get_plugin_conf(product_list, "/product_list", "")
+    job["resampled_scenes"] = {}
+    scn = job["scene"]
+    for area in product_list["product_list"]["areas"]:
+        area_conf = _get_plugin_conf(
+            product_list, "/product_list/areas/" + str(area), conf
+        )
+        logger.info("Cropping to %s", str(area))
+
+        # Load composites before cropping, otherwise cropping fails for composites
+        scn.load(scn.wishlist, generate=True)
+        # If area is none, no cropping is done.
+        if area != "None":
+            logger.debug("area: %s, area_conf: %s", area, str(area_conf))
+            job["resampled_scenes"][area] = scn.crop(area)
 
 # Datasets saving
 


### PR DESCRIPTION
An addition for using the scene.crop() functionality from `satpy` has been added to `trollflow2. It can be called in the `trollflow2.yaml` file with `- fun: !!python/name:trollflow2.plugins.crop. This functionality was implemented because I was tasked with cropping geostationary data and saving it to the local archive. The aim of this approach was to preserve the data in its original form while reducing overall storage space by retaining only the data over the region of interest.

The `crop()` function was added, which uses the same output `job["resampled_scenes"]` as `resample(), so they cannot be used simultaneously. However, no situations have been identified where using both functions at the same time would be necessary.<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
