### PR TITLE
Add handling for SIGTERM

### DIFF
--- a/doc/source/launcher.rst
+++ b/doc/source/launcher.rst
@@ -11,3 +11,7 @@ messages by starting ``satpy_launcher.py`` with command-line arguments
 ``-n False -a tcp://<host>:<port>`` where the host and port point to a
 message publisher. Multiple publisher addresses can be given by supplying
 them with additional ``-a`` switches.
+
+The Trollflow2 process can be terminated gracefully by sending SIGTERM
+to the it, eg. by ``kill -SIGTERM <pid>`` where ``<pid>`` is the
+process ID number of Trollflow2.

--- a/doc/source/launcher.rst
+++ b/doc/source/launcher.rst
@@ -14,4 +14,6 @@ them with additional ``-a`` switches.
 
 The Trollflow2 process can be terminated gracefully by sending SIGTERM
 to the it, eg. by ``kill -SIGTERM <pid>`` where ``<pid>`` is the
-process ID number of Trollflow2.
+process ID number of Trollflow2.  After this no new messages will be
+accepted, and the completion of currently running processing will exit
+Trollflow2.

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -153,7 +153,6 @@ def generate_messages(connection_parameters):
         logger.info(
             "Caught signal to stop processing new messages and to terminate Trollflow2.")
         keep_looping = False
-        listener.stop()
 
     signal.signal(signal.SIGTERM, _signal_handler)
 
@@ -165,10 +164,11 @@ def generate_messages(connection_parameters):
                 logger.debug(f"{str(msg)}")
                 yield msg
         except KeyboardInterrupt:
-            listener.stop()
-            return
+            break
         except Empty:
             continue
+
+    listener.stop()
 
 
 def _create_listener_from_connection_parameters(connection_parameters):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -146,7 +146,18 @@ def _check_local_file(saved_file):
 def generate_messages(connection_parameters):
     """Generate messages using a ListenerContainer."""
     listener = _create_listener_from_connection_parameters(connection_parameters)
-    while True:
+    keep_looping = True
+
+    def _signal_handler(signum, frame):
+        nonlocal keep_looping
+        logger.info(
+            "Caught signal to stop processing new messages and to terminate Trollflow2.")
+        keep_looping = False
+        listener.stop()
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    while keep_looping:
         try:
             msg = listener.output_queue.get(True, 5)
             if msg.type in VALID_MESSAGE_TYPES:

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -158,7 +158,7 @@ def generate_messages(connection_parameters):
 
     while keep_looping:
         try:
-            msg = listener.output_queue.get(True, 5)
+            msg = listener.output_queue.get(True, 1)
             if msg.type in VALID_MESSAGE_TYPES:
                 logger.info("New message received.")
                 logger.debug(f"{str(msg)}")

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -887,15 +887,15 @@ def test_generate_messages():
             assert msg.type in VALID_MESSAGE_TYPES
 
 
-def test_sigterm_generate_messages():
+def test_sigterm_generate_messages(tmp_path):
     """Test that sending sigterm to Trollflow2 stops it."""
     import os
     import signal
     from multiprocessing import Process
 
     from trollflow2.launcher import generate_messages
-
-    connection_parameters = {"nameserver": False, "addresses": "localhost:40000", "topic": "/test"}
+    ipc_path = os.fspath(tmp_path / "my_pipe")
+    connection_parameters = {"nameserver": False, "addresses": f"ipc://{ipc_path}", "topic": "/test"}
     proc = Process(target=generate_messages, args=(connection_parameters, ))
     proc.start()
     # Wait for the message listening loop to start

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -907,19 +907,33 @@ def test_sigterm_generate_messages():
     assert proc.exitcode == 0
 
 
-def test_sigterm_runner(tmp_path):
+def _fake_queue_logged_process(msg, prod_list, produced_files, **kwargs):
+    time.sleep(5.0)
+
+
+@mock.patch("trollflow2.launcher.ListenerContainer")
+@mock.patch("trollflow2.launcher.queue_logged_process",
+            new=_fake_queue_logged_process)
+def test_sigterm_runner(lc_, tmp_path, caplog):
     """Test that sending sigterm to Trollflow2 stops it."""
     import os
     import signal
-    import time
     from multiprocessing import Process
 
+    from posttroll.message import Message
+
     from trollflow2.launcher import Runner
+
+    msg = Message('/my/topic', atype='file', data={'filename': 'foo'})
+    listener = mock.MagicMock()
+    listener.output_queue.get.return_value = msg
+    lc_.return_value = listener
 
     product_list = tmp_path / "trollflow2.yaml"
     with open(product_list, "w") as fid:
         fid.write(yaml_test1)
-    connection_parameters = {"nameserver": False, "addresses": "localhost:40000", "topic": "/test"}
+
+    connection_parameters = {}
     runner = Runner(product_list, connection_parameters)
     proc = Process(target=runner.run)
     proc.start()
@@ -931,10 +945,10 @@ def test_sigterm_runner(tmp_path):
     proc.join()
 
     assert proc.exitcode == 0
-    # The queue.get timeout is set to 5 seconds, so it should be at
-    # least this long until the process is terminated
+    # The fake processing takes 5 seconds, so it should be at least
+    # this long until the process is terminated
     elapsed_time = time.time() - tic
-    assert elapsed_time >= 5.0
+    assert elapsed_time > 5.0
 
 
 if __name__ == '__main__':

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -914,7 +914,7 @@ def _fake_queue_logged_process(msg, prod_list, produced_files, **kwargs):
 @mock.patch("trollflow2.launcher.ListenerContainer")
 @mock.patch("trollflow2.launcher.queue_logged_process",
             new=_fake_queue_logged_process)
-def test_sigterm_runner(lc_, tmp_path, caplog):
+def test_sigterm_runner(lc_, tmp_path):
     """Test that sending sigterm to Trollflow2 stops it."""
     import os
     import signal

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -918,7 +918,7 @@ def test_sigterm_runner(lc_, tmp_path, caplog):
     """Test that sending sigterm to Trollflow2 stops it."""
     import os
     import signal
-    from multiprocessing import Process
+    from multiprocessing import Process, set_start_method
 
     from posttroll.message import Message
 
@@ -935,6 +935,8 @@ def test_sigterm_runner(lc_, tmp_path, caplog):
 
     connection_parameters = {}
     runner = Runner(product_list, connection_parameters)
+
+    set_start_method("spawn")
     proc = Process(target=runner.run)
     proc.start()
     tic = time.time()

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -891,7 +891,6 @@ def test_sigterm_generate_messages():
     """Test that sending sigterm to Trollflow2 stops it."""
     import os
     import signal
-    import time
     from multiprocessing import Process
 
     from trollflow2.launcher import generate_messages
@@ -899,7 +898,6 @@ def test_sigterm_generate_messages():
     connection_parameters = {"nameserver": False, "addresses": "localhost:40000", "topic": "/test"}
     proc = Process(target=generate_messages, args=(connection_parameters, ))
     proc.start()
-    tic = time.time()
     # Wait for the message listening loop to start
     time.sleep(1)
     # Send SIGTERM
@@ -907,10 +905,6 @@ def test_sigterm_generate_messages():
     proc.join()
 
     assert proc.exitcode == 0
-    # The queue.get timeout is set to 5 seconds, so it should be at
-    # least this long until the process is terminated
-    elapsed_time = time.time() - tic
-    assert elapsed_time >= 5.0
 
 
 def test_sigterm_runner(tmp_path):

--- a/trollflow2/tests/test_launcher.py
+++ b/trollflow2/tests/test_launcher.py
@@ -918,7 +918,7 @@ def test_sigterm_runner(lc_, tmp_path, caplog):
     """Test that sending sigterm to Trollflow2 stops it."""
     import os
     import signal
-    from multiprocessing import Process, set_start_method
+    from multiprocessing import Process
 
     from posttroll.message import Message
 
@@ -936,7 +936,6 @@ def test_sigterm_runner(lc_, tmp_path, caplog):
     connection_parameters = {}
     runner = Runner(product_list, connection_parameters)
 
-    set_start_method("spawn")
     proc = Process(target=runner.run)
     proc.start()
     tic = time.time()


### PR DESCRIPTION
This PR adds handling for SIGTERM signal, so that Trollflow2 can be terminated gracefully in for example container environment.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
