### PR TITLE
Fix log message printing the number of loaded composites

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -100,7 +100,8 @@ def load_composites(job):
         else:
             composites_by_res.setdefault(res, set()).add(flat_prod_cfg['product'])
 
-    logger.info(f"Loading {len(composites_by_res)} composites.")
+    num_composites = sum([len(composites_by_res[d]) for d in composites_by_res])
+    logger.info(f"Loading {num_composites} composites.")
 
     scn = job['scene']
     generate = job['product_list']['product_list'].get('delay_composites', True) is False

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -844,6 +844,11 @@ class TestCreateScene(TestCase):
 class TestLoadComposites(TestCase):
     """Test case for loading composites."""
 
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        """Inject fixtures."""
+        self._caplog = caplog
+
     def setUp(self):
         """Set up the test case."""
         super().setUp()
@@ -855,7 +860,9 @@ class TestLoadComposites(TestCase):
         from trollflow2.plugins import DEFAULT, load_composites
         scn = _get_mocked_scene_with_properties()
         job = {"product_list": self.product_list, "scene": scn}
-        load_composites(job)
+        with self._caplog.at_level(logging.INFO):
+            load_composites(job)
+        assert "Loading 3 composites." in self._caplog.text
         scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'}, resolution=DEFAULT, generate=False)
 
     def test_load_composites_with_config(self):
@@ -865,7 +872,9 @@ class TestLoadComposites(TestCase):
         self.product_list['product_list']['resolution'] = 1000
         self.product_list['product_list']['delay_composites'] = False
         job = {"product_list": self.product_list, "scene": scn}
-        load_composites(job)
+        with self._caplog.at_level(logging.INFO):
+            load_composites(job)
+        assert "Loading 3 composites." in self._caplog.text
         scn.load.assert_called_with({'ct', 'cloudtype', 'cloud_top_height'}, resolution=1000, generate=True)
 
     def test_load_composites_with_different_resolutions(self):
@@ -876,7 +885,9 @@ class TestLoadComposites(TestCase):
         self.product_list['product_list']['areas']['euron1']['resolution'] = 500
         self.product_list['product_list']['delay_composites'] = False
         job = {"product_list": self.product_list, "scene": scn}
-        load_composites(job)
+        with self._caplog.at_level(logging.INFO):
+            load_composites(job)
+        assert "Loading 4 composites." in self._caplog.text
         scn.load.assert_any_call({'cloudtype', 'ct', 'cloud_top_height'}, resolution=1000, generate=True)
         scn.load.assert_any_call({'cloud_top_height'}, resolution=500, generate=True)
 
@@ -886,7 +897,9 @@ class TestLoadComposites(TestCase):
         scn = _get_mocked_scene_with_properties()
         self.product_list['product_list']['scene_load_kwargs'] = {"upper_right_corner": "NE"}
         job = {"product_list": self.product_list, "scene": scn}
-        load_composites(job)
+        with self._caplog.at_level(logging.INFO):
+            load_composites(job)
+        assert "Loading 3 composites." in self._caplog.text
         scn.load.assert_called_with(
             {'ct', 'cloudtype', 'cloud_top_height'},
             resolution=DEFAULT, generate=False, upper_right_corner="NE")


### PR DESCRIPTION
Trollflow2 is printing a log message saying `Loading 1 composites` even when there are more. This PR fixes the log message.

 - [x] Tests added  <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
