### PR TITLE
Remove references to removed plugins

### DIFF
--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -273,16 +273,6 @@ Options:
    than defined, the data are not processed for this area.  By default
    process all areas.
 
-Platform name check
-*******************
-
-The ``check_platform`` plugin can be used to check that the platform
-name in the incoming message is in the configured list of platforms.
-The best place for this plugin is before any data handling is done.
-
-Options:
- - ``processed_platforms: null`` - A list of allowed platform names.  By
-   default (``null``) all platforms are processed.
 
 Metadata checks
 ***************

--- a/doc/source/product_list.rst
+++ b/doc/source/product_list.rst
@@ -91,8 +91,6 @@ Example
                 fname_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name:s}_{productname:s}_{variant:s}.{format}"
 
   workers:
-    - fun: !!python/name:trollflow2.plugins.check_platform
-    - fun: !!python/name:trollflow2.plugins.check_sensor
     - fun: !!python/name:trollflow2.plugins.create_scene
     - fun: !!python/name:trollflow2.plugins.check_sunlight_coverage
     - fun: !!python/name:trollflow2.plugins.covers


### PR DESCRIPTION
This PR removes references to removed plugins from the documentation.

 - [x] Closes #98 
