### PR TITLE
Fix trollsched usage when not installed

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -639,8 +639,8 @@ def _check_overall_coverage_for_area(
     Helper for covers().
     """
     area_path = "/product_list/areas/%s" % area
-    cov = get_scene_coverage(platform_name, start_time, end_time,
-                             sensor, area)
+    cov = _get_scene_coverage(platform_name, start_time, end_time,
+                              sensor, area)
     product_list['product_list']['areas'][area]['area_coverage_percent'] = cov
     if cov < min_coverage:
         logger.info(
@@ -654,7 +654,7 @@ def _check_overall_coverage_for_area(
                      f"{min_coverage:.2f}% - Carry on with {area:s}")
 
 
-def get_scene_coverage(platform_name, start_time, end_time, sensor, area_id):
+def _get_scene_coverage(platform_name, start_time, end_time, sensor, area_id):
     """Get scene area coverage in percentages."""
     overpass = Pass(platform_name, start_time, end_time, instrument=sensor)
     area_def = get_area_def(area_id)
@@ -1028,8 +1028,8 @@ def _product_meets_min_valid_data_fraction(
     end_time = prod.attrs["end_time"]
     sensor = prod.attrs["sensor"]
     if area_name not in exp_cov:
-        # get_scene_coverage uses %, convert to fraction
-        exp_cov[area_name] = get_scene_coverage(
+        # _get_scene_coverage uses %, convert to fraction
+        exp_cov[area_name] = _get_scene_coverage(
             platform_name, start_time, end_time, sensor, area_name)/100
     exp_valid = exp_cov[area_name]
     if exp_valid == 0:

--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -968,6 +968,11 @@ def check_valid_data_fraction(job):
     """
     logger.info("Checking valid data fraction.")
 
+    if get_twilight_poly is None:
+        logger.error("Trollsched import failed, calculation of valid data fraction not possible")
+        logger.info("Keeping all products")
+        return
+
     exp_cov = {}
     # As stated, this will trigger a computation.  To prevent computing
     # multiple times, we should persist everything that needs to be persisted,

--- a/trollflow2/tests/test_trollflow2.py
+++ b/trollflow2/tests/test_trollflow2.py
@@ -1347,9 +1347,9 @@ class TestCovers(TestCase):
         """Test that the plugin complains when multiple sensors are provided."""
         from trollflow2.plugins import covers
 
-        with mock.patch('trollflow2.plugins.get_scene_coverage') as get_scene_coverage, \
+        with mock.patch('trollflow2.plugins._get_scene_coverage') as _get_scene_coverage, \
                 mock.patch('trollflow2.plugins.Pass'):
-            get_scene_coverage.return_value = 10.0
+            _get_scene_coverage.return_value = 10.0
             scn = _get_mocked_scene_with_properties()
             job = {"product_list": self.product_list,
                    "input_mda": {"platform_name": "platform",
@@ -1365,9 +1365,9 @@ class TestCovers(TestCase):
         """Test that the plugin complains when multiple sensors are provided."""
         from trollflow2.plugins import covers
 
-        with mock.patch('trollflow2.plugins.get_scene_coverage') as get_scene_coverage, \
+        with mock.patch('trollflow2.plugins._get_scene_coverage') as _get_scene_coverage, \
                 mock.patch('trollflow2.plugins.Pass'):
-            get_scene_coverage.return_value = 10.0
+            _get_scene_coverage.return_value = 10.0
             scn = _get_mocked_scene_with_properties()
             job = {"product_list": self.product_list,
                    "input_mda": {"platform_name": "platform",
@@ -1383,19 +1383,19 @@ class TestCovers(TestCase):
         """Test that the scene and message metadata are merged correctly."""
         from trollflow2.plugins import covers
 
-        with mock.patch('trollflow2.plugins.get_scene_coverage') as get_scene_coverage, \
+        with mock.patch('trollflow2.plugins._get_scene_coverage') as _get_scene_coverage, \
                 mock.patch('trollflow2.plugins.Pass'):
-            get_scene_coverage.return_value = 10.0
+            _get_scene_coverage.return_value = 10.0
             scn = _get_mocked_scene_with_properties()
             job = {"product_list": self.product_list,
                    "input_mda": {"platform_name": "platform"},
                    "scene": scn}
             covers(job)
-            get_scene_coverage.assert_called_with(job["input_mda"]["platform_name"],
-                                                  scn.start_time,
-                                                  scn.end_time,
-                                                  list(scn.sensor_names)[0],
-                                                  "omerc_bb")
+            _get_scene_coverage.assert_called_with(job["input_mda"]["platform_name"],
+                                                   scn.start_time,
+                                                   scn.end_time,
+                                                   list(scn.sensor_names)[0],
+                                                   "omerc_bb")
 
     def test_covers(self):
         """Test coverage."""
@@ -1429,14 +1429,14 @@ class TestCovers(TestCase):
                "scene": scn}
         job2 = copy.deepcopy(job)
 
-        with mock.patch('trollflow2.plugins.get_scene_coverage') as get_scene_coverage, \
+        with mock.patch('trollflow2.plugins._get_scene_coverage') as _get_scene_coverage, \
                 mock.patch('trollflow2.plugins.Pass'):
-            get_scene_coverage.return_value = 10.0
+            _get_scene_coverage.return_value = 10.0
             covers(job)
-            get_scene_coverage.assert_called_with(input_mda['platform_name'],
-                                                  input_mda['start_time'],
-                                                  input_mda['end_time'],
-                                                  'avhrr-4', 'omerc_bb')
+            _get_scene_coverage.assert_called_with(input_mda['platform_name'],
+                                                   input_mda['start_time'],
+                                                   input_mda['end_time'],
+                                                   'avhrr-4', 'omerc_bb')
 
             del job2["product_list"]["product_list"]["areas"]["euron1"]["min_coverage"]
             del job2["product_list"]["product_list"]["min_coverage"]
@@ -1446,7 +1446,7 @@ class TestCovers(TestCase):
 
     def test_scene_coverage(self):
         """Test scene coverage."""
-        from trollflow2.plugins import get_scene_coverage
+        from trollflow2.plugins import _get_scene_coverage
         with mock.patch('trollflow2.plugins.get_area_def') as get_area_def, \
                 mock.patch('trollflow2.plugins.Pass') as ts_pass:
             area_coverage = mock.MagicMock()
@@ -1455,7 +1455,7 @@ class TestCovers(TestCase):
             overpass.area_coverage = area_coverage
             ts_pass.return_value = overpass
             get_area_def.return_value = 6
-            res = get_scene_coverage(1, 2, 3, 4, 5)
+            res = _get_scene_coverage(1, 2, 3, 4, 5)
             self.assertEqual(res, 100 * 0.2)
             ts_pass.assert_called_with(1, 2, 3, instrument=4)
             get_area_def.assert_called_with(5)
@@ -2185,7 +2185,7 @@ def test_valid_filter(caplog, sc_3a_3b):
     job2 = copy.deepcopy(job)
     prods2 = job2['product_list']['product_list']['areas']['euron1']['products']
 
-    with mock.patch("trollflow2.plugins.get_scene_coverage") as tpg, \
+    with mock.patch("trollflow2.plugins._get_scene_coverage") as tpg, \
             caplog.at_level(logging.DEBUG):
         tpg.return_value = 100
         check_valid_data_fraction(job)


### PR DESCRIPTION
The `check_valid_data_fraction()` doesn't have a check whether pytroll-schedule is installed or not.

This PR adds the check, and makes the `get_scene_coverage()` helper function a private function to show it should not be called directly.

 - [x] Closes #222 
 - [x] Tests updated
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
