### PR TITLE
Fix version where area and writer imports were changed

### DIFF
--- a/trollflow2/plugins/__init__.py
+++ b/trollflow2/plugins/__init__.py
@@ -47,7 +47,7 @@ from satpy import Scene
 from satpy.version import version as satpy_version
 from trollsift import compose
 
-if satpy_version >= "0.59.0":
+if satpy_version >= "0.58.0":
     from satpy.area import get_area_def
     from satpy.writers.core.compute import (compute_writer_results,
                                             group_results_by_output_file,


### PR DESCRIPTION
While testing for upcoming processing updates, I noticed that I still got warnings about some imports being from the "old" Satpy packages. The reason was that the Satpy version number was set to `0.59.0` while the changes were already in `0.58.0`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added  <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 trollflow2`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
